### PR TITLE
 suggest using RELEASE.local to avoid editing RELEASE file in two places

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -8,9 +8,7 @@ TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
 # define INSTALL_LOCATION_APP here
 #INSTALL_LOCATION_APP=<fullpathname>
 
-# SUPPORT=/home/xspress3/epics must be defined in RELEASE.local
-# RELEASE.local will be used to build iocs/xspres3IOC/bin/[distribution]/xspress3App
--include $(TOP)/../configure/RELEASE.local
+SUPPORT=/home/xspress3/epics
 
 # This module
 XSPRESS3=$(SUPPORT)/xspress3

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -8,7 +8,9 @@ TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
 # define INSTALL_LOCATION_APP here
 #INSTALL_LOCATION_APP=<fullpathname>
 
-SUPPORT=/home/xspress3/epics
+# SUPPORT=/home/xspress3/epics must be defined in RELEASE.local
+# RELEASE.local will be used to build iocs/xspres3IOC/bin/[distribution]/xspress3App
+-include $(TOP)/../configure/RELEASE.local
 
 # This module
 XSPRESS3=$(SUPPORT)/xspress3

--- a/iocs/xspress3IOC/configure/RELEASE
+++ b/iocs/xspress3IOC/configure/RELEASE
@@ -2,10 +2,9 @@
 # Run "gnumake clean uninstall install" in the application
 # top directory each time this file is changed.
 
-SUPPORT=/home/xspress3/epics
-
 # This module
 XSPRESS3=$(TOP)/../..
+include $(XSPRESS3)/configure/RELEASE
 
 # XSPRESS3 requires areaDetector, and areaDetector/configure already defines
 # ASYN, CALC, etc.

--- a/iocs/xspress3IOC/configure/RELEASE
+++ b/iocs/xspress3IOC/configure/RELEASE
@@ -2,8 +2,7 @@
 # Run "gnumake clean uninstall install" in the application
 # top directory each time this file is changed.
 
-# SUPPORT= should be defined in xspress3/configure/RELEASE.local
--include $(TOP)/../../configure/RELEASE.local
+SUPPORT=/home/xspress3/epics
 
 # This module
 XSPRESS3=$(TOP)/../..

--- a/iocs/xspress3IOC/configure/RELEASE
+++ b/iocs/xspress3IOC/configure/RELEASE
@@ -2,7 +2,8 @@
 # Run "gnumake clean uninstall install" in the application
 # top directory each time this file is changed.
 
-SUPPORT=/home/xspress3/epics
+# SUPPORT= should be defined in xspress3/configure/RELEASE.local
+-include $(TOP)/../../configure/RELEASE.local
 
 # This module
 XSPRESS3=$(TOP)/../..


### PR DESCRIPTION
Hi, I cloned master branch to CentOS 7 and was having build errors: 
........
make -C ./iocs install 
make[1]: Entering directory `/opt/epicsTest/support/xspress3/iocs'
make -C ./xspress3IOC install 
make[2]: Entering directory `/opt/epicsTest/support/xspress3/iocs/xspress3IOC'
configure/CONFIG:17: /configure/CONFIG: No such file or directory
configure/RULES_TOP:2: /configure/RULES_TOP: No such file or directory
make[2]: *** No rule to make target `/configure/RULES_TOP'.  Stop.
make[2]: Leaving directory `/opt/epicsTest/support/xspress3/iocs/xspress3IOC'
make[1]: *** [xspress3IOC.install] Error 2
make[1]: Leaving directory `/opt/epicsTest/support/xspress3/iocs'
make: *** [iocs.install] Error 2

@jwlodek pointed that I need to define SUPPORT in iocs/xpres3IOC/configure/RELEASE, which I did and it worked. However, it did not feel right. I looked at how areaDetector modules handle this situation having only top level defining user specific locations, and came up with this PR. Just before creating it I read the extensive  discussion in issue #11. :)  My fix is not exactly the same as areaDetector handles the situation. It would be if I could make iocs/xpres3IOC/configure/RELEASE use the toplevel RELEASE file, not RELEASE.local. But  the concept of using RELEASE.local file for site specific definitions is the direction we are going, and I included comments.  I think this is definitely better than having a build error and not expecting that one needs to modify the second RELEASE file. Perhaps others could reflect and improve the suggested change to make it 100% elegant. 

