### PR TITLE
fixing typo, ADXSPRESS3 is not provided by envPaths, XSPRESS3 is. tested

### DIFF
--- a/iocs/xspress3IOC/iocBoot/iocDualMini_4Channel/st.cmd
+++ b/iocs/xspress3IOC/iocBoot/iocDualMini_4Channel/st.cmd
@@ -33,7 +33,7 @@ epicsEnvSet("MAXFRAMES", "16384")
 # The maximum number of frames buffered in the NDPluginCircularBuff plugin
 epicsEnvSet("CBUFFS", "500")
 # The search path for database files
-epicsEnvSet("EPICS_DB_INCLUDE_PATH", "$(ADCORE)/db:$(ADXSPRESS3)/db:.")
+epicsEnvSet("EPICS_DB_INCLUDE_PATH", "$(ADCORE)/db:$(XSPRESS3)/db:.")
 
 
 #DevIOCStats

--- a/iocs/xspress3IOC/iocBoot/ioc_14Channel/st.cmd
+++ b/iocs/xspress3IOC/iocBoot/ioc_14Channel/st.cmd
@@ -32,7 +32,7 @@ epicsEnvSet("MAXFRAMES", "16384")
 # The maximum number of frames buffered in the NDPluginCircularBuff plugin
 epicsEnvSet("CBUFFS", "500")
 # The search path for database files
-epicsEnvSet("EPICS_DB_INCLUDE_PATH", "$(ADCORE)/db:$(ADXSPRESS3)/db:.")
+epicsEnvSet("EPICS_DB_INCLUDE_PATH", "$(ADCORE)/db:$(XSPRESS3)/db:.")
 
 #DevIOCStats
 dbLoadRecords("$(DEVIOCSTATS)/db/iocAdminSoft.db", "IOC=$(IOC)")

--- a/iocs/xspress3IOC/iocBoot/iocxspress3-4Channel/st.cmd
+++ b/iocs/xspress3IOC/iocBoot/iocxspress3-4Channel/st.cmd
@@ -32,7 +32,7 @@ epicsEnvSet("MAXFRAMES", "16384")
 # The maximum number of frames buffered in the NDPluginCircularBuff plugin
 epicsEnvSet("CBUFFS", "500")
 # The search path for database files
-epicsEnvSet("EPICS_DB_INCLUDE_PATH", "$(ADCORE)/db:$(ADXSPRESS3)/db:.")
+epicsEnvSet("EPICS_DB_INCLUDE_PATH", "$(ADCORE)/db:$(XSPRESS3)/db:.")
 
 
 #DevIOCStats


### PR DESCRIPTION
Hello,
I think this is a typo somehow crept in, unless there is more to it.  ADXSPRESS3  macro is not defined anywhere. It is my understanding XSPRESS3  was meant. 
Thanks. 