### PR TITLE
add 'EraseOnStart' option to for runtime switch of whether Acquire does an Erase 

### DIFF
--- a/iocs/xspress3IOC/iocBoot/common/SetMainValues.cmd
+++ b/iocs/xspress3IOC/iocBoot/common/SetMainValues.cmd
@@ -6,6 +6,7 @@ dbpf("$(PREFIX)det1:AcquireTime",  0.25)
 dbpf("$(PREFIX)det1:CONNECT",      "1")
 dbpf("$(PREFIX)det1:CTRL_DTC",     "Disable")
 dbpf("$(PREFIX)det1:TriggerMode",  "Internal")
+dbpf("$(PREFIX)det1:EraseOnStart", "Yes")
 
 #Enable Array Callbacks, set Attributes file
 dbpf("$(PREFIX)det1:ArrayCallbacks",   "Enable")

--- a/iocs/xspress3IOC/iocBoot/iocGSECARS-7Channel/defaultValueLoad.cmd
+++ b/iocs/xspress3IOC/iocBoot/iocGSECARS-7Channel/defaultValueLoad.cmd
@@ -28,6 +28,7 @@ dbpf("$(PREFIX)det1:AcquireTime", 0.25)
 dbpf("$(PREFIX)det1:CONNECT","1")
 dbpf("$(PREFIX)det1:CTRL_DTC",  "Disable")
 dbpf("$(PREFIX)det1:TriggerMode","Internal")
+dbpf("$(PREFIX)det1:EraseOnStart","Yes")
 
 #Setup Channel 1
 epicsEnvSet("CHAN",   "1")

--- a/xspress3App/Db/xspress3.template
+++ b/xspress3App/Db/xspress3.template
@@ -48,6 +48,17 @@ record(bi, "$(P)$(R)Acquire_RBV") {
    field(OSV,  "NO_ALARM")
 }
 
+# ///
+# /// Set whether Acquire erases first
+# ///
+record(bo, "$(P)$(R)EraseOnStart") {
+   field(DTYP, "asynInt32")
+   field(OUT, "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))XSP3_ERASESTART")
+   field(ZNAM, "No")
+   field(ONAM, "Yes")
+   field(VAL,  "1")
+}
+
 
 # ///
 # /// Set the numer of channels to read out.

--- a/xspress3App/Db/xspress3ChannelDeadtime.template
+++ b/xspress3App/Db/xspress3ChannelDeadtime.template
@@ -7,19 +7,17 @@ record(ao, "$(P)C$(CHAN):EventWidth") {
 }
 
 # percent deadtime = allevent*event width + time in reset
-record(ai, "$(P)C$(CHAN):DeadTime_RBV") {
+record(ao, "$(P)C$(CHAN):DeadTime_RBV") {
     field(DTYP, "asynFloat64")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))XSP3_CHAN_DTPERCENT")
-    field(SCAN, "I/O Intr")
     field(VAL,  "0")
     field(PREC, "5")
 }
 
 # deadtime correction factor 
-record(ai, "$(P)C$(CHAN):DTFactor_RBV") {
+record(ao, "$(P)C$(CHAN):DTFactor_RBV") {
     field(DTYP, "asynFloat64")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))XSP3_CHAN_DTFACTOR")
-    field(SCAN, "I/O Intr")
     field(VAL,  "1")
     field(PREC, "5")
 }

--- a/xspress3App/opi/adl/xspress3_14chan.adl
+++ b/xspress3App/opi/adl/xspress3_14chan.adl
@@ -1,12 +1,12 @@
 
 file {
-	name="/home/epics/support/xspress3/xspress3App/opi/adl/xspress3_14chan.adl"
-	version=030109
+	name="/home/xspress3/epics/xspress3/xspress3App/opi/adl/xspress3_14chan.adl"
+	version=030112
 }
 display {
 	object {
-		x=690
-		y=186
+		x=400
+		y=250
 		width=450
 		height=525
 	}
@@ -330,9 +330,9 @@ text {
 }
 "text entry" {
 	object {
-		x=102
+		x=120
 		y=120
-		width=100
+		width=80
 		height=20
 	}
 	control {
@@ -342,32 +342,6 @@ text {
 	}
 	limits {
 	}
-}
-"choice button" {
-	object {
-		x=155
-		y=175
-		width=120
-		height=20
-	}
-	control {
-		chan="$(P):det1:CTRL_DTC"
-		clr=14
-		bclr=3
-	}
-	stacking="column"
-}
-text {
-	object {
-		x=5
-		y=180
-		width=150
-		height=15
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Dead Time Corr"
 }
 text {
 	object {
@@ -570,22 +544,7 @@ byte {
 }
 "text update" {
 	object {
-		x=280
-		y=175
-		width=120
-		height=15
-	}
-	monitor {
-		chan="$(P):det1:CTRL_DTC_RBV"
-		clr=54
-		bclr=0
-	}
-	limits {
-	}
-}
-"text update" {
-	object {
-		x=285
+		x=270
 		y=210
 		width=120
 		height=15
@@ -600,7 +559,7 @@ byte {
 }
 menu {
 	object {
-		x=155
+		x=120
 		y=210
 		width=120
 		height=20
@@ -626,9 +585,9 @@ text {
 }
 "text entry" {
 	object {
-		x=102
+		x=120
 		y=145
-		width=100
+		width=80
 		height=20
 	}
 	control {
@@ -1016,4 +975,30 @@ menu {
 	clr=54
 	bclr=55
 	label="-Combined Plots"
+}
+text {
+	object {
+		x=5
+		y=180
+		width=110
+		height=15
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Erase on Start?"
+}
+"choice button" {
+	object {
+		x=120
+		y=175
+		width=120
+		height=20
+	}
+	control {
+		chan="$(P):det1:EraseOnStart"
+		clr=14
+		bclr=3
+	}
+	stacking="column"
 }

--- a/xspress3App/opi/adl/xspress3_16chan.adl
+++ b/xspress3App/opi/adl/xspress3_16chan.adl
@@ -1,12 +1,12 @@
 
 file {
-	name="/home/epics/support/xspress3/xspress3App/opi/adl/xspress3_16chan.adl"
-	version=030109
+	name="/home/xspress3/epics/xspress3/xspress3App/opi/adl/xspress3_16chan.adl"
+	version=030112
 }
 display {
 	object {
-		x=690
-		y=186
+		x=400
+		y=250
 		width=450
 		height=525
 	}
@@ -330,9 +330,9 @@ text {
 }
 "text entry" {
 	object {
-		x=102
+		x=120
 		y=120
-		width=100
+		width=80
 		height=20
 	}
 	control {
@@ -342,32 +342,6 @@ text {
 	}
 	limits {
 	}
-}
-"choice button" {
-	object {
-		x=155
-		y=175
-		width=120
-		height=20
-	}
-	control {
-		chan="$(P):det1:CTRL_DTC"
-		clr=14
-		bclr=3
-	}
-	stacking="column"
-}
-text {
-	object {
-		x=5
-		y=180
-		width=150
-		height=15
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Dead Time Corr"
 }
 text {
 	object {
@@ -570,22 +544,7 @@ byte {
 }
 "text update" {
 	object {
-		x=280
-		y=175
-		width=120
-		height=15
-	}
-	monitor {
-		chan="$(P):det1:CTRL_DTC_RBV"
-		clr=54
-		bclr=0
-	}
-	limits {
-	}
-}
-"text update" {
-	object {
-		x=285
+		x=270
 		y=210
 		width=120
 		height=15
@@ -600,7 +559,7 @@ byte {
 }
 menu {
 	object {
-		x=155
+		x=120
 		y=210
 		width=120
 		height=20
@@ -626,9 +585,9 @@ text {
 }
 "text entry" {
 	object {
-		x=102
+		x=120
 		y=145
-		width=100
+		width=80
 		height=20
 	}
 	control {
@@ -1020,4 +979,30 @@ menu {
 	clr=54
 	bclr=55
 	label="-Combined Plots"
+}
+text {
+	object {
+		x=5
+		y=180
+		width=110
+		height=15
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Erase on Start?"
+}
+"choice button" {
+	object {
+		x=120
+		y=175
+		width=120
+		height=20
+	}
+	control {
+		chan="$(P):det1:EraseOnStart"
+		clr=14
+		bclr=3
+	}
+	stacking="column"
 }

--- a/xspress3App/opi/adl/xspress3_1chan.adl
+++ b/xspress3App/opi/adl/xspress3_1chan.adl
@@ -1,12 +1,12 @@
 
 file {
-	name="/home/epics/support/xspress3-2-2/xspress3App/opi/adl/xspress3_1chan.adl"
-	version=030109
+	name="/home/xspress3/epics/xspress3/xspress3App/opi/adl/xspress3_1chan.adl"
+	version=030112
 }
 display {
 	object {
-		x=207
-		y=68
+		x=200
+		y=100
 		width=450
 		height=525
 	}
@@ -240,7 +240,7 @@ text {
 "text update" {
 	object {
 		x=360
-		y=140
+		y=145
 		width=75
 		height=15
 	}
@@ -281,7 +281,7 @@ text {
 text {
 	object {
 		x=300
-		y=140
+		y=145
 		width=50
 		height=15
 	}
@@ -304,9 +304,9 @@ text {
 }
 "text entry" {
 	object {
-		x=102
+		x=120
 		y=120
-		width=100
+		width=80
 		height=20
 	}
 	control {
@@ -319,13 +319,13 @@ text {
 }
 "choice button" {
 	object {
-		x=155
+		x=120
 		y=175
 		width=120
 		height=20
 	}
 	control {
-		chan="$(P):det1:CTRL_DTC"
+		chan="$(P):det1:EraseOnStart"
 		clr=14
 		bclr=3
 	}
@@ -335,13 +335,13 @@ text {
 	object {
 		x=5
 		y=180
-		width=150
+		width=130
 		height=15
 	}
 	"basic attribute" {
 		clr=14
 	}
-	textix="Dead Time Corr"
+	textix="Erase on Start?"
 }
 text {
 	object {
@@ -541,22 +541,7 @@ byte {
 }
 "text update" {
 	object {
-		x=280
-		y=175
-		width=120
-		height=15
-	}
-	monitor {
-		chan="$(P):det1:CTRL_DTC_RBV"
-		clr=54
-		bclr=0
-	}
-	limits {
-	}
-}
-"text update" {
-	object {
-		x=285
+		x=270
 		y=210
 		width=120
 		height=15
@@ -571,7 +556,7 @@ byte {
 }
 menu {
 	object {
-		x=155
+		x=120
 		y=210
 		width=120
 		height=20
@@ -597,9 +582,9 @@ text {
 }
 "text entry" {
 	object {
-		x=102
+		x=120
 		y=145
-		width=100
+		width=80
 		height=20
 	}
 	control {

--- a/xspress3App/opi/adl/xspress3_1chan.adl
+++ b/xspress3App/opi/adl/xspress3_1chan.adl
@@ -5,8 +5,8 @@ file {
 }
 display {
 	object {
-		x=200
-		y=100
+		x=400
+		y=250
 		width=450
 		height=525
 	}
@@ -335,7 +335,7 @@ text {
 	object {
 		x=5
 		y=180
-		width=130
+		width=110
 		height=15
 	}
 	"basic attribute" {

--- a/xspress3App/opi/adl/xspress3_2chan.adl
+++ b/xspress3App/opi/adl/xspress3_2chan.adl
@@ -5,8 +5,8 @@ file {
 }
 display {
 	object {
-		x=200
-		y=100
+		x=400
+		y=250
 		width=450
 		height=525
 	}
@@ -361,7 +361,7 @@ text {
 	object {
 		x=5
 		y=180
-		width=130
+		width=110
 		height=15
 	}
 	"basic attribute" {

--- a/xspress3App/opi/adl/xspress3_2chan.adl
+++ b/xspress3App/opi/adl/xspress3_2chan.adl
@@ -1,12 +1,12 @@
 
 file {
-	name="/home/epics/support/xspress3/xspress3App/opi/adl/xspress3_2chan.adl"
-	version=030109
+	name="/home/xspress3/epics/xspress3/xspress3App/opi/adl/xspress3_2chan.adl"
+	version=030112
 }
 display {
 	object {
-		x=207
-		y=68
+		x=200
+		y=100
 		width=450
 		height=525
 	}
@@ -240,7 +240,7 @@ text {
 "text update" {
 	object {
 		x=360
-		y=140
+		y=145
 		width=75
 		height=15
 	}
@@ -281,7 +281,7 @@ text {
 text {
 	object {
 		x=300
-		y=140
+		y=145
 		width=50
 		height=15
 	}
@@ -330,9 +330,9 @@ text {
 }
 "text entry" {
 	object {
-		x=102
+		x=120
 		y=120
-		width=100
+		width=80
 		height=20
 	}
 	control {
@@ -345,13 +345,13 @@ text {
 }
 "choice button" {
 	object {
-		x=155
+		x=120
 		y=175
 		width=120
 		height=20
 	}
 	control {
-		chan="$(P):det1:CTRL_DTC"
+		chan="$(P):det1:EraseOnStart"
 		clr=14
 		bclr=3
 	}
@@ -361,13 +361,13 @@ text {
 	object {
 		x=5
 		y=180
-		width=150
+		width=130
 		height=15
 	}
 	"basic attribute" {
 		clr=14
 	}
-	textix="Dead Time Corr"
+	textix="Erase on Start?"
 }
 text {
 	object {
@@ -567,22 +567,7 @@ byte {
 }
 "text update" {
 	object {
-		x=280
-		y=175
-		width=120
-		height=15
-	}
-	monitor {
-		chan="$(P):det1:CTRL_DTC_RBV"
-		clr=54
-		bclr=0
-	}
-	limits {
-	}
-}
-"text update" {
-	object {
-		x=285
+		x=270
 		y=210
 		width=120
 		height=15
@@ -597,7 +582,7 @@ byte {
 }
 menu {
 	object {
-		x=155
+		x=120
 		y=210
 		width=120
 		height=20
@@ -613,7 +598,7 @@ text {
 	object {
 		x=5
 		y=150
-		width=100
+		width=80
 		height=15
 	}
 	"basic attribute" {
@@ -623,9 +608,9 @@ text {
 }
 "text entry" {
 	object {
-		x=102
+		x=120
 		y=145
-		width=100
+		width=80
 		height=20
 	}
 	control {

--- a/xspress3App/opi/adl/xspress3_4chan.adl
+++ b/xspress3App/opi/adl/xspress3_4chan.adl
@@ -1,12 +1,12 @@
 
 file {
-	name="/home/epics/support/xspress3-2-2/xspress3App/opi/adl/xspress3_4chan.adl"
-	version=030109
+	name="/home/xspress3/epics/xspress3/xspress3App/opi/adl/xspress3_4chan.adl"
+	version=030112
 }
 display {
 	object {
-		x=207
-		y=68
+		x=400
+		y=250
 		width=450
 		height=525
 	}
@@ -330,9 +330,9 @@ text {
 }
 "text entry" {
 	object {
-		x=102
+		x=120
 		y=120
-		width=100
+		width=80
 		height=20
 	}
 	control {
@@ -342,32 +342,6 @@ text {
 	}
 	limits {
 	}
-}
-"choice button" {
-	object {
-		x=155
-		y=175
-		width=120
-		height=20
-	}
-	control {
-		chan="$(P):det1:CTRL_DTC"
-		clr=14
-		bclr=3
-	}
-	stacking="column"
-}
-text {
-	object {
-		x=5
-		y=180
-		width=150
-		height=15
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Dead Time Corr"
 }
 text {
 	object {
@@ -567,22 +541,7 @@ byte {
 }
 "text update" {
 	object {
-		x=280
-		y=175
-		width=120
-		height=15
-	}
-	monitor {
-		chan="$(P):det1:CTRL_DTC_RBV"
-		clr=54
-		bclr=0
-	}
-	limits {
-	}
-}
-"text update" {
-	object {
-		x=285
+		x=270
 		y=210
 		width=120
 		height=15
@@ -597,7 +556,7 @@ byte {
 }
 menu {
 	object {
-		x=155
+		x=120
 		y=210
 		width=120
 		height=20
@@ -623,9 +582,9 @@ text {
 }
 "text entry" {
 	object {
-		x=102
+		x=120
 		y=145
-		width=100
+		width=80
 		height=20
 	}
 	control {
@@ -990,4 +949,30 @@ menu {
 	clr=54
 	bclr=55
 	label="-Combined Plots"
+}
+text {
+	object {
+		x=5
+		y=180
+		width=110
+		height=15
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Erase on Start?"
+}
+"choice button" {
+	object {
+		x=120
+		y=175
+		width=120
+		height=20
+	}
+	control {
+		chan="$(P):det1:EraseOnStart"
+		clr=14
+		bclr=3
+	}
+	stacking="column"
 }

--- a/xspress3App/opi/adl/xspress3_7chan.adl
+++ b/xspress3App/opi/adl/xspress3_7chan.adl
@@ -5,8 +5,8 @@ file {
 }
 display {
 	object {
-		x=690
-		y=186
+		x=400
+		y=250
 		width=450
 		height=525
 	}
@@ -330,9 +330,9 @@ text {
 }
 "text entry" {
 	object {
-		x=102
+		x=120
 		y=120
-		width=100
+		width=80
 		height=20
 	}
 	control {
@@ -342,32 +342,6 @@ text {
 	}
 	limits {
 	}
-}
-"choice button" {
-	object {
-		x=155
-		y=175
-		width=120
-		height=20
-	}
-	control {
-		chan="$(P):det1:CTRL_DTC"
-		clr=14
-		bclr=3
-	}
-	stacking="column"
-}
-text {
-	object {
-		x=5
-		y=180
-		width=150
-		height=15
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Dead Time Corr"
 }
 text {
 	object {
@@ -567,22 +541,7 @@ byte {
 }
 "text update" {
 	object {
-		x=280
-		y=175
-		width=120
-		height=15
-	}
-	monitor {
-		chan="$(P):det1:CTRL_DTC_RBV"
-		clr=54
-		bclr=0
-	}
-	limits {
-	}
-}
-"text update" {
-	object {
-		x=285
+		x=270
 		y=210
 		width=120
 		height=15
@@ -597,7 +556,7 @@ byte {
 }
 menu {
 	object {
-		x=155
+		x=120
 		y=210
 		width=120
 		height=20
@@ -623,9 +582,9 @@ text {
 }
 "text entry" {
 	object {
-		x=102
+		x=120
 		y=145
-		width=100
+		width=80
 		height=20
 	}
 	control {
@@ -982,4 +941,30 @@ menu {
 	clr=54
 	bclr=55
 	label="-Combined Plots"
+}
+text {
+	object {
+		x=5
+		y=180
+		width=110
+		height=15
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Erase on Start?"
+}
+"choice button" {
+	object {
+		x=120
+		y=175
+		width=120
+		height=20
+	}
+	control {
+		chan="$(P):det1:EraseOnStart"
+		clr=14
+		bclr=3
+	}
+	stacking="column"
 }

--- a/xspress3App/opi/adl/xspress3_8chan.adl
+++ b/xspress3App/opi/adl/xspress3_8chan.adl
@@ -1,12 +1,12 @@
 
 file {
-	name="/home/epics/support/xspress3/xspress3App/opi/adl/xspress3_8chan.adl"
-	version=030109
+	name="/home/xspress3/epics/xspress3/xspress3App/opi/adl/xspress3_8chan.adl"
+	version=030112
 }
 display {
 	object {
-		x=690
-		y=186
+		x=400
+		y=250
 		width=450
 		height=525
 	}
@@ -330,9 +330,9 @@ text {
 }
 "text entry" {
 	object {
-		x=102
+		x=120
 		y=120
-		width=100
+		width=80
 		height=20
 	}
 	control {
@@ -342,32 +342,6 @@ text {
 	}
 	limits {
 	}
-}
-"choice button" {
-	object {
-		x=155
-		y=175
-		width=120
-		height=20
-	}
-	control {
-		chan="$(P):det1:CTRL_DTC"
-		clr=14
-		bclr=3
-	}
-	stacking="column"
-}
-text {
-	object {
-		x=5
-		y=180
-		width=150
-		height=15
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Dead Time Corr"
 }
 text {
 	object {
@@ -570,22 +544,7 @@ byte {
 }
 "text update" {
 	object {
-		x=280
-		y=175
-		width=120
-		height=15
-	}
-	monitor {
-		chan="$(P):det1:CTRL_DTC_RBV"
-		clr=54
-		bclr=0
-	}
-	limits {
-	}
-}
-"text update" {
-	object {
-		x=285
+		x=270
 		y=210
 		width=120
 		height=15
@@ -600,7 +559,7 @@ byte {
 }
 menu {
 	object {
-		x=155
+		x=120
 		y=210
 		width=120
 		height=20
@@ -626,9 +585,9 @@ text {
 }
 "text entry" {
 	object {
-		x=102
+		x=120
 		y=145
-		width=100
+		width=80
 		height=20
 	}
 	control {
@@ -980,4 +939,30 @@ menu {
 	clr=54
 	bclr=55
 	label="-Combined Plots"
+}
+text {
+	object {
+		x=5
+		y=180
+		width=110
+		height=15
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Erase on Start?"
+}
+"choice button" {
+	object {
+		x=120
+		y=175
+		width=120
+		height=20
+	}
+	control {
+		chan="$(P):det1:EraseOnStart"
+		clr=14
+		bclr=3
+	}
+	stacking="column"
 }

--- a/xspress3App/opi/bob/xspress3_14chan.bob
+++ b/xspress3App/opi/bob/xspress3_14chan.bob
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <display version="2.0.0">
   <name>xspress3_14chan</name>
-  <x>690</x>
-  <y>186</y>
+  <x>400</x>
+  <y>250</y>
   <width>450</width>
   <height>525</height>
   <background_color>
@@ -299,8 +299,9 @@
   <widget type="textentry" version="3.0.0">
     <name>text entry #63</name>
     <pv_name>$(P):det1:NumImages</pv_name>
-    <x>102</x>
+    <x>120</x>
     <y>120</y>
+    <width>80</width>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
       </font>
@@ -313,38 +314,8 @@
     <show_units>false</show_units>
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
-  <widget type="choice" version="2.0.0">
-    <name>choice button #67</name>
-    <pv_name>$(P):det1:CTRL_DTC</pv_name>
-    <x>155</x>
-    <y>175</y>
-    <width>120</width>
-    <height>20</height>
-    <background_color>
-      <color red="200" green="200" blue="200">
-      </color>
-    </background_color>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <items>
-      <item>Item 1</item>
-      <item>Item 2</item>
-    </items>
-  </widget>
   <widget type="label" version="2.0.0">
-    <name>text #70</name>
-    <text>Dead Time Corr</text>
-    <x>5</x>
-    <y>180</y>
-    <width>150</width>
-    <height>15</height>
-    <font>
-      <font family="Liberation Sans" style="REGULAR" size="16.0">
-      </font>
-    </font>
-    <auto_size>true</auto_size>
-  </widget>
-  <widget type="label" version="2.0.0">
-    <name>text #73</name>
+    <name>text #67</name>
     <text>Trigger</text>
     <x>5</x>
     <y>215</y>
@@ -352,7 +323,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #76</name>
+    <name>text entry #70</name>
     <pv_name>$(P):HDF1:FilePath</pv_name>
     <x>100</x>
     <y>315</y>
@@ -370,7 +341,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #80</name>
+    <name>text #74</name>
     <text>File Prefix</text>
     <x>10</x>
     <y>348</y>
@@ -378,7 +349,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #83</name>
+    <name>text entry #77</name>
     <pv_name>$(P):HDF1:FileName</pv_name>
     <x>100</x>
     <y>345</y>
@@ -396,7 +367,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #87</name>
+    <name>text #81</name>
     <text>File Number</text>
     <x>230</x>
     <y>348</y>
@@ -405,7 +376,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #90</name>
+    <name>text entry #84</name>
     <pv_name>$(P):HDF1:FileNumber</pv_name>
     <x>320</x>
     <y>346</y>
@@ -422,7 +393,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
-    <name>bar #94</name>
+    <name>bar #88</name>
     <pv_name>$(P):HDF1:FilePathExists_RBV</pv_name>
     <x>425</x>
     <y>315</y>
@@ -436,7 +407,7 @@
     </foreground_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>message button #97</name>
+    <name>message button #91</name>
     <actions>
       <action type="write_pv">
         <pv_name>$(P):HDF1:Capture</pv_name>
@@ -459,7 +430,7 @@
     </background_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>message button #100</name>
+    <name>message button #94</name>
     <actions>
       <action type="write_pv">
         <pv_name>$(P):HDF1:Capture</pv_name>
@@ -482,7 +453,7 @@
     </background_color>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
-    <name>bar #103</name>
+    <name>bar #97</name>
     <pv_name>$(P):HDF1:Capture_RBV</pv_name>
     <x>420</x>
     <y>250</y>
@@ -496,7 +467,7 @@
     </foreground_color>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
-    <name>bar #106</name>
+    <name>bar #100</name>
     <pv_name>$(P):HDF1:WriteStatus</pv_name>
     <x>425</x>
     <y>491</y>
@@ -510,7 +481,7 @@
     </foreground_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #109</name>
+    <name>related display #103</name>
     <actions>
       <action type="open_display">
         <file>ADBase.opi</file>
@@ -558,7 +529,7 @@
     </background_color>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #115</name>
+    <name>text update #109</name>
     <pv_name>$(P):det1:NumImages_RBV</pv_name>
     <x>210</x>
     <y>120</y>
@@ -581,32 +552,9 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #119</name>
-    <pv_name>$(P):det1:CTRL_DTC_RBV</pv_name>
-    <x>280</x>
-    <y>175</y>
-    <width>120</width>
-    <height>15</height>
-    <font>
-      <font family="Liberation Sans" style="REGULAR" size="16.0">
-      </font>
-    </font>
-    <foreground_color>
-      <color red="10" green="0" blue="184">
-      </color>
-    </foreground_color>
-    <background_color>
-      <color red="255" green="255" blue="255">
-      </color>
-    </background_color>
-    <format>1</format>
-    <show_units>false</show_units>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-  </widget>
-  <widget type="textupdate" version="2.0.0">
-    <name>text update #123</name>
+    <name>text update #113</name>
     <pv_name>$(P):det1:TriggerMode_RBV</pv_name>
-    <x>285</x>
+    <x>270</x>
     <y>210</y>
     <width>120</width>
     <height>15</height>
@@ -627,9 +575,9 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #127</name>
+    <name>menu #117</name>
     <pv_name>$(P):det1:TriggerMode</pv_name>
-    <x>155</x>
+    <x>120</x>
     <y>210</y>
     <width>120</width>
     <height>20</height>
@@ -644,7 +592,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #130</name>
+    <name>text #120</name>
     <text>Dwell Time</text>
     <x>5</x>
     <y>150</y>
@@ -656,10 +604,11 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #133</name>
+    <name>text entry #123</name>
     <pv_name>$(P):det1:AcquireTime</pv_name>
-    <x>102</x>
+    <x>120</x>
     <y>145</y>
+    <width>80</width>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
       </font>
@@ -673,7 +622,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #137</name>
+    <name>text update #127</name>
     <pv_name>$(P):det1:AcquireTime_RBV</pv_name>
     <x>210</x>
     <y>145</y>
@@ -696,7 +645,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #141</name>
+    <name>text #131</name>
     <text>Control &amp; Status</text>
     <x>10</x>
     <y>59</y>
@@ -708,7 +657,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #144</name>
+    <name>text #134</name>
     <text>HDF5 File Saving</text>
     <x>5</x>
     <y>250</y>
@@ -720,7 +669,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #147</name>
+    <name>text #137</name>
     <text>File Path</text>
     <x>10</x>
     <y>318</y>
@@ -728,7 +677,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #150</name>
+    <name>text #140</name>
     <text>Capturing</text>
     <x>335</x>
     <y>250</y>
@@ -741,7 +690,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #153</name>
+    <name>text #143</name>
     <text>Status</text>
     <x>10</x>
     <y>491</y>
@@ -750,7 +699,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #156</name>
+    <name>text update #146</name>
     <pv_name>$(P):HDF1:WriteMessage</pv_name>
     <x>100</x>
     <y>491</y>
@@ -773,7 +722,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #160</name>
+    <name>text update #150</name>
     <pv_name>$(P):det1:StatusMessage_RBV</pv_name>
     <x>170</x>
     <y>5</y>
@@ -796,7 +745,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #164</name>
+    <name>text #154</name>
     <text>Frames Saved</text>
     <x>10</x>
     <y>441</y>
@@ -805,7 +754,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #167</name>
+    <name>text update #157</name>
     <pv_name>$(P):HDF1:NumCaptured_RBV</pv_name>
     <x>100</x>
     <y>441</y>
@@ -827,7 +776,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #171</name>
+    <name>text #161</name>
     <text>Compression</text>
     <x>10</x>
     <y>406</y>
@@ -835,7 +784,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #174</name>
+    <name>menu #164</name>
     <pv_name>$(P):HDF1:Compression</pv_name>
     <x>100</x>
     <y>404</y>
@@ -851,7 +800,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #177</name>
+    <name>text #167</name>
     <text>ZLevel:</text>
     <x>230</x>
     <y>406</y>
@@ -860,7 +809,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #180</name>
+    <name>text entry #170</name>
     <pv_name>$(P):HDF1:ZLevel</pv_name>
     <x>320</x>
     <y>406</y>
@@ -877,7 +826,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #184</name>
+    <name>text #174</name>
     <text>Last File</text>
     <x>10</x>
     <y>466</y>
@@ -885,7 +834,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #187</name>
+    <name>text update #177</name>
     <pv_name>$(P):HDF1:FullFileName_RBV</pv_name>
     <x>100</x>
     <y>466</y>
@@ -908,7 +857,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #191</name>
+    <name>text #181</name>
     <text>File Format</text>
     <x>10</x>
     <y>376</y>
@@ -917,7 +866,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #194</name>
+    <name>text entry #184</name>
     <pv_name>$(P):HDF1:FileTemplate</pv_name>
     <x>100</x>
     <y>376</y>
@@ -935,7 +884,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #198</name>
+    <name>text #188</name>
     <text>Auto Number</text>
     <x>230</x>
     <y>376</y>
@@ -944,7 +893,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #201</name>
+    <name>menu #191</name>
     <pv_name>$(P):HDF1:AutoIncrement</pv_name>
     <x>320</x>
     <y>375</y>
@@ -960,7 +909,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #204</name>
+    <name>related display #194</name>
     <actions>
       <action type="open_display">
         <file>xspress3_mcarois.opi</file>
@@ -1089,7 +1038,7 @@
     </background_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #222</name>
+    <name>related display #212</name>
     <actions>
       <action type="open_display">
         <file>xspress3_16mcas.opi</file>
@@ -1121,5 +1070,35 @@
       <color red="235" green="241" blue="181">
       </color>
     </background_color>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>text #216</name>
+    <text>Erase on Start?</text>
+    <x>5</x>
+    <y>180</y>
+    <width>110</width>
+    <height>15</height>
+    <font>
+      <font family="Liberation Sans" style="REGULAR" size="16.0">
+      </font>
+    </font>
+    <auto_size>true</auto_size>
+  </widget>
+  <widget type="choice" version="2.0.0">
+    <name>choice button #219</name>
+    <pv_name>$(P):det1:EraseOnStart</pv_name>
+    <x>120</x>
+    <y>175</y>
+    <width>120</width>
+    <height>20</height>
+    <background_color>
+      <color red="200" green="200" blue="200">
+      </color>
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <items>
+      <item>Item 1</item>
+      <item>Item 2</item>
+    </items>
   </widget>
 </display>

--- a/xspress3App/opi/bob/xspress3_16chan.bob
+++ b/xspress3App/opi/bob/xspress3_16chan.bob
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <display version="2.0.0">
   <name>xspress3_16chan</name>
-  <x>690</x>
-  <y>186</y>
+  <x>400</x>
+  <y>250</y>
   <width>450</width>
   <height>525</height>
   <background_color>
@@ -299,8 +299,9 @@
   <widget type="textentry" version="3.0.0">
     <name>text entry #63</name>
     <pv_name>$(P):det1:NumImages</pv_name>
-    <x>102</x>
+    <x>120</x>
     <y>120</y>
+    <width>80</width>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
       </font>
@@ -313,38 +314,8 @@
     <show_units>false</show_units>
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
-  <widget type="choice" version="2.0.0">
-    <name>choice button #67</name>
-    <pv_name>$(P):det1:CTRL_DTC</pv_name>
-    <x>155</x>
-    <y>175</y>
-    <width>120</width>
-    <height>20</height>
-    <background_color>
-      <color red="200" green="200" blue="200">
-      </color>
-    </background_color>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <items>
-      <item>Item 1</item>
-      <item>Item 2</item>
-    </items>
-  </widget>
   <widget type="label" version="2.0.0">
-    <name>text #70</name>
-    <text>Dead Time Corr</text>
-    <x>5</x>
-    <y>180</y>
-    <width>150</width>
-    <height>15</height>
-    <font>
-      <font family="Liberation Sans" style="REGULAR" size="16.0">
-      </font>
-    </font>
-    <auto_size>true</auto_size>
-  </widget>
-  <widget type="label" version="2.0.0">
-    <name>text #73</name>
+    <name>text #67</name>
     <text>Trigger</text>
     <x>5</x>
     <y>215</y>
@@ -352,7 +323,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #76</name>
+    <name>text entry #70</name>
     <pv_name>$(P):HDF1:FilePath</pv_name>
     <x>100</x>
     <y>315</y>
@@ -370,7 +341,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #80</name>
+    <name>text #74</name>
     <text>File Prefix</text>
     <x>10</x>
     <y>348</y>
@@ -378,7 +349,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #83</name>
+    <name>text entry #77</name>
     <pv_name>$(P):HDF1:FileName</pv_name>
     <x>100</x>
     <y>345</y>
@@ -396,7 +367,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #87</name>
+    <name>text #81</name>
     <text>File Number</text>
     <x>230</x>
     <y>348</y>
@@ -405,7 +376,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #90</name>
+    <name>text entry #84</name>
     <pv_name>$(P):HDF1:FileNumber</pv_name>
     <x>320</x>
     <y>346</y>
@@ -422,7 +393,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
-    <name>bar #94</name>
+    <name>bar #88</name>
     <pv_name>$(P):HDF1:FilePathExists_RBV</pv_name>
     <x>425</x>
     <y>315</y>
@@ -436,7 +407,7 @@
     </foreground_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>message button #97</name>
+    <name>message button #91</name>
     <actions>
       <action type="write_pv">
         <pv_name>$(P):HDF1:Capture</pv_name>
@@ -459,7 +430,7 @@
     </background_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>message button #100</name>
+    <name>message button #94</name>
     <actions>
       <action type="write_pv">
         <pv_name>$(P):HDF1:Capture</pv_name>
@@ -482,7 +453,7 @@
     </background_color>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
-    <name>bar #103</name>
+    <name>bar #97</name>
     <pv_name>$(P):HDF1:Capture_RBV</pv_name>
     <x>420</x>
     <y>250</y>
@@ -496,7 +467,7 @@
     </foreground_color>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
-    <name>bar #106</name>
+    <name>bar #100</name>
     <pv_name>$(P):HDF1:WriteStatus</pv_name>
     <x>425</x>
     <y>491</y>
@@ -510,7 +481,7 @@
     </foreground_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #109</name>
+    <name>related display #103</name>
     <actions>
       <action type="open_display">
         <file>ADBase.opi</file>
@@ -558,7 +529,7 @@
     </background_color>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #115</name>
+    <name>text update #109</name>
     <pv_name>$(P):det1:NumImages_RBV</pv_name>
     <x>210</x>
     <y>120</y>
@@ -581,32 +552,9 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #119</name>
-    <pv_name>$(P):det1:CTRL_DTC_RBV</pv_name>
-    <x>280</x>
-    <y>175</y>
-    <width>120</width>
-    <height>15</height>
-    <font>
-      <font family="Liberation Sans" style="REGULAR" size="16.0">
-      </font>
-    </font>
-    <foreground_color>
-      <color red="10" green="0" blue="184">
-      </color>
-    </foreground_color>
-    <background_color>
-      <color red="255" green="255" blue="255">
-      </color>
-    </background_color>
-    <format>1</format>
-    <show_units>false</show_units>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-  </widget>
-  <widget type="textupdate" version="2.0.0">
-    <name>text update #123</name>
+    <name>text update #113</name>
     <pv_name>$(P):det1:TriggerMode_RBV</pv_name>
-    <x>285</x>
+    <x>270</x>
     <y>210</y>
     <width>120</width>
     <height>15</height>
@@ -627,9 +575,9 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #127</name>
+    <name>menu #117</name>
     <pv_name>$(P):det1:TriggerMode</pv_name>
-    <x>155</x>
+    <x>120</x>
     <y>210</y>
     <width>120</width>
     <height>20</height>
@@ -644,7 +592,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #130</name>
+    <name>text #120</name>
     <text>Dwell Time</text>
     <x>5</x>
     <y>150</y>
@@ -656,10 +604,11 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #133</name>
+    <name>text entry #123</name>
     <pv_name>$(P):det1:AcquireTime</pv_name>
-    <x>102</x>
+    <x>120</x>
     <y>145</y>
+    <width>80</width>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
       </font>
@@ -673,7 +622,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #137</name>
+    <name>text update #127</name>
     <pv_name>$(P):det1:AcquireTime_RBV</pv_name>
     <x>210</x>
     <y>145</y>
@@ -696,7 +645,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #141</name>
+    <name>text #131</name>
     <text>Control &amp; Status</text>
     <x>10</x>
     <y>59</y>
@@ -708,7 +657,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #144</name>
+    <name>text #134</name>
     <text>HDF5 File Saving</text>
     <x>5</x>
     <y>250</y>
@@ -720,7 +669,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #147</name>
+    <name>text #137</name>
     <text>File Path</text>
     <x>10</x>
     <y>318</y>
@@ -728,7 +677,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #150</name>
+    <name>text #140</name>
     <text>Capturing</text>
     <x>335</x>
     <y>250</y>
@@ -741,7 +690,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #153</name>
+    <name>text #143</name>
     <text>Status</text>
     <x>10</x>
     <y>491</y>
@@ -750,7 +699,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #156</name>
+    <name>text update #146</name>
     <pv_name>$(P):HDF1:WriteMessage</pv_name>
     <x>100</x>
     <y>491</y>
@@ -773,7 +722,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #160</name>
+    <name>text update #150</name>
     <pv_name>$(P):det1:StatusMessage_RBV</pv_name>
     <x>170</x>
     <y>5</y>
@@ -796,7 +745,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #164</name>
+    <name>text #154</name>
     <text>Frames Saved</text>
     <x>10</x>
     <y>441</y>
@@ -805,7 +754,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #167</name>
+    <name>text update #157</name>
     <pv_name>$(P):HDF1:NumCaptured_RBV</pv_name>
     <x>100</x>
     <y>441</y>
@@ -827,7 +776,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #171</name>
+    <name>text #161</name>
     <text>Compression</text>
     <x>10</x>
     <y>406</y>
@@ -835,7 +784,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #174</name>
+    <name>menu #164</name>
     <pv_name>$(P):HDF1:Compression</pv_name>
     <x>100</x>
     <y>404</y>
@@ -851,7 +800,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #177</name>
+    <name>text #167</name>
     <text>ZLevel:</text>
     <x>230</x>
     <y>406</y>
@@ -860,7 +809,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #180</name>
+    <name>text entry #170</name>
     <pv_name>$(P):HDF1:ZLevel</pv_name>
     <x>320</x>
     <y>406</y>
@@ -877,7 +826,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #184</name>
+    <name>text #174</name>
     <text>Last File</text>
     <x>10</x>
     <y>466</y>
@@ -885,7 +834,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #187</name>
+    <name>text update #177</name>
     <pv_name>$(P):HDF1:FullFileName_RBV</pv_name>
     <x>100</x>
     <y>466</y>
@@ -908,7 +857,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #191</name>
+    <name>text #181</name>
     <text>File Format</text>
     <x>10</x>
     <y>376</y>
@@ -917,7 +866,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #194</name>
+    <name>text entry #184</name>
     <pv_name>$(P):HDF1:FileTemplate</pv_name>
     <x>100</x>
     <y>376</y>
@@ -935,7 +884,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #198</name>
+    <name>text #188</name>
     <text>Auto Number</text>
     <x>230</x>
     <y>376</y>
@@ -944,7 +893,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #201</name>
+    <name>menu #191</name>
     <pv_name>$(P):HDF1:AutoIncrement</pv_name>
     <x>320</x>
     <y>375</y>
@@ -960,7 +909,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #204</name>
+    <name>related display #194</name>
     <actions>
       <action type="open_display">
         <file>xspress3_mcarois.opi</file>
@@ -1105,7 +1054,7 @@
     </background_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #222</name>
+    <name>related display #212</name>
     <actions>
       <action type="open_display">
         <file>xspress3_16mcas.opi</file>
@@ -1137,5 +1086,35 @@
       <color red="235" green="241" blue="181">
       </color>
     </background_color>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>text #216</name>
+    <text>Erase on Start?</text>
+    <x>5</x>
+    <y>180</y>
+    <width>110</width>
+    <height>15</height>
+    <font>
+      <font family="Liberation Sans" style="REGULAR" size="16.0">
+      </font>
+    </font>
+    <auto_size>true</auto_size>
+  </widget>
+  <widget type="choice" version="2.0.0">
+    <name>choice button #219</name>
+    <pv_name>$(P):det1:EraseOnStart</pv_name>
+    <x>120</x>
+    <y>175</y>
+    <width>120</width>
+    <height>20</height>
+    <background_color>
+      <color red="200" green="200" blue="200">
+      </color>
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <items>
+      <item>Item 1</item>
+      <item>Item 2</item>
+    </items>
   </widget>
 </display>

--- a/xspress3App/opi/bob/xspress3_1chan.bob
+++ b/xspress3App/opi/bob/xspress3_1chan.bob
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <display version="2.0.0">
   <name>xspress3_1chan</name>
-  <x>207</x>
-  <y>68</y>
+  <x>400</x>
+  <y>250</y>
   <width>450</width>
   <height>525</height>
   <background_color>
@@ -203,7 +203,7 @@
     <name>text update #41</name>
     <pv_name>$(P):det1:ArrayRate_RBV</pv_name>
     <x>360</x>
-    <y>140</y>
+    <y>145</y>
     <width>75</width>
     <height>15</height>
     <font>
@@ -248,7 +248,7 @@
     <name>text #51</name>
     <text>Rate</text>
     <x>300</x>
-    <y>140</y>
+    <y>145</y>
     <width>50</width>
     <height>15</height>
     <font>
@@ -272,8 +272,9 @@
   <widget type="textentry" version="3.0.0">
     <name>text entry #57</name>
     <pv_name>$(P):det1:NumImages</pv_name>
-    <x>102</x>
+    <x>120</x>
     <y>120</y>
+    <width>80</width>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
       </font>
@@ -288,8 +289,8 @@
   </widget>
   <widget type="choice" version="2.0.0">
     <name>choice button #61</name>
-    <pv_name>$(P):det1:CTRL_DTC</pv_name>
-    <x>155</x>
+    <pv_name>$(P):det1:EraseOnStart</pv_name>
+    <x>120</x>
     <y>175</y>
     <width>120</width>
     <height>20</height>
@@ -305,10 +306,10 @@
   </widget>
   <widget type="label" version="2.0.0">
     <name>text #64</name>
-    <text>Dead Time Corr</text>
+    <text>Erase on Start?</text>
     <x>5</x>
     <y>180</y>
-    <width>150</width>
+    <width>110</width>
     <height>15</height>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
@@ -551,31 +552,8 @@
   </widget>
   <widget type="textupdate" version="2.0.0">
     <name>text update #112</name>
-    <pv_name>$(P):det1:CTRL_DTC_RBV</pv_name>
-    <x>280</x>
-    <y>175</y>
-    <width>120</width>
-    <height>15</height>
-    <font>
-      <font family="Liberation Sans" style="REGULAR" size="16.0">
-      </font>
-    </font>
-    <foreground_color>
-      <color red="10" green="0" blue="184">
-      </color>
-    </foreground_color>
-    <background_color>
-      <color red="255" green="255" blue="255">
-      </color>
-    </background_color>
-    <format>1</format>
-    <show_units>false</show_units>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-  </widget>
-  <widget type="textupdate" version="2.0.0">
-    <name>text update #116</name>
     <pv_name>$(P):det1:TriggerMode_RBV</pv_name>
-    <x>285</x>
+    <x>270</x>
     <y>210</y>
     <width>120</width>
     <height>15</height>
@@ -596,9 +574,9 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #120</name>
+    <name>menu #116</name>
     <pv_name>$(P):det1:TriggerMode</pv_name>
-    <x>155</x>
+    <x>120</x>
     <y>210</y>
     <width>120</width>
     <height>20</height>
@@ -613,7 +591,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #123</name>
+    <name>text #119</name>
     <text>Dwell Time</text>
     <x>5</x>
     <y>150</y>
@@ -625,10 +603,11 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #126</name>
+    <name>text entry #122</name>
     <pv_name>$(P):det1:AcquireTime</pv_name>
-    <x>102</x>
+    <x>120</x>
     <y>145</y>
+    <width>80</width>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
       </font>
@@ -642,7 +621,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #130</name>
+    <name>text update #126</name>
     <pv_name>$(P):det1:AcquireTime_RBV</pv_name>
     <x>210</x>
     <y>145</y>
@@ -665,7 +644,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #134</name>
+    <name>text #130</name>
     <text>Control &amp; Status</text>
     <x>10</x>
     <y>59</y>
@@ -677,7 +656,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #137</name>
+    <name>text #133</name>
     <text>HDF5 File Saving</text>
     <x>5</x>
     <y>250</y>
@@ -689,7 +668,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #140</name>
+    <name>text #136</name>
     <text>File Path</text>
     <x>10</x>
     <y>318</y>
@@ -697,7 +676,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #143</name>
+    <name>text #139</name>
     <text>Capturing</text>
     <x>335</x>
     <y>250</y>
@@ -710,7 +689,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #146</name>
+    <name>text #142</name>
     <text>Status</text>
     <x>10</x>
     <y>491</y>
@@ -719,7 +698,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #149</name>
+    <name>text update #145</name>
     <pv_name>$(P):HDF1:WriteMessage</pv_name>
     <x>100</x>
     <y>491</y>
@@ -742,7 +721,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #153</name>
+    <name>text update #149</name>
     <pv_name>$(P):det1:StatusMessage_RBV</pv_name>
     <x>170</x>
     <y>5</y>
@@ -765,7 +744,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #157</name>
+    <name>text #153</name>
     <text>Frames Saved</text>
     <x>10</x>
     <y>441</y>
@@ -774,7 +753,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #160</name>
+    <name>text update #156</name>
     <pv_name>$(P):HDF1:NumCaptured_RBV</pv_name>
     <x>100</x>
     <y>441</y>
@@ -796,7 +775,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #164</name>
+    <name>text #160</name>
     <text>Compression</text>
     <x>10</x>
     <y>406</y>
@@ -804,7 +783,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #167</name>
+    <name>menu #163</name>
     <pv_name>$(P):HDF1:Compression</pv_name>
     <x>100</x>
     <y>404</y>
@@ -820,7 +799,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #170</name>
+    <name>text #166</name>
     <text>ZLevel:</text>
     <x>230</x>
     <y>406</y>
@@ -829,7 +808,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #173</name>
+    <name>text entry #169</name>
     <pv_name>$(P):HDF1:ZLevel</pv_name>
     <x>320</x>
     <y>406</y>
@@ -846,7 +825,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #177</name>
+    <name>text #173</name>
     <text>Last File</text>
     <x>10</x>
     <y>466</y>
@@ -854,7 +833,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #180</name>
+    <name>text update #176</name>
     <pv_name>$(P):HDF1:FullFileName_RBV</pv_name>
     <x>100</x>
     <y>466</y>
@@ -877,7 +856,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #184</name>
+    <name>text #180</name>
     <text>File Format</text>
     <x>10</x>
     <y>376</y>
@@ -886,7 +865,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #187</name>
+    <name>text entry #183</name>
     <pv_name>$(P):HDF1:FileTemplate</pv_name>
     <x>100</x>
     <y>376</y>
@@ -904,7 +883,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #191</name>
+    <name>text #187</name>
     <text>Auto Number</text>
     <x>230</x>
     <y>376</y>
@@ -913,7 +892,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #194</name>
+    <name>menu #190</name>
     <pv_name>$(P):HDF1:AutoIncrement</pv_name>
     <x>320</x>
     <y>375</y>
@@ -929,7 +908,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #197</name>
+    <name>related display #193</name>
     <actions>
       <action type="open_display">
         <file>xspress3_mcarois.opi</file>
@@ -955,7 +934,7 @@
     </background_color>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
-    <name>bar #200</name>
+    <name>bar #196</name>
     <pv_name>$(P):det1:CONNECTED</pv_name>
     <x>330</x>
     <y>60</y>
@@ -969,7 +948,7 @@
     </foreground_color>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #203</name>
+    <name>text #199</name>
     <text>Connected</text>
     <x>260</x>
     <y>60</y>

--- a/xspress3App/opi/bob/xspress3_2chan.bob
+++ b/xspress3App/opi/bob/xspress3_2chan.bob
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <display version="2.0.0">
   <name>xspress3_2chan</name>
-  <x>207</x>
-  <y>68</y>
+  <x>400</x>
+  <y>250</y>
   <width>450</width>
   <height>525</height>
   <background_color>
@@ -203,7 +203,7 @@
     <name>text update #41</name>
     <pv_name>$(P):det1:ArrayRate_RBV</pv_name>
     <x>360</x>
-    <y>140</y>
+    <y>145</y>
     <width>75</width>
     <height>15</height>
     <font>
@@ -248,7 +248,7 @@
     <name>text #51</name>
     <text>Rate</text>
     <x>300</x>
-    <y>140</y>
+    <y>145</y>
     <width>50</width>
     <height>15</height>
     <font>
@@ -299,8 +299,9 @@
   <widget type="textentry" version="3.0.0">
     <name>text entry #63</name>
     <pv_name>$(P):det1:NumImages</pv_name>
-    <x>102</x>
+    <x>120</x>
     <y>120</y>
+    <width>80</width>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
       </font>
@@ -315,8 +316,8 @@
   </widget>
   <widget type="choice" version="2.0.0">
     <name>choice button #67</name>
-    <pv_name>$(P):det1:CTRL_DTC</pv_name>
-    <x>155</x>
+    <pv_name>$(P):det1:EraseOnStart</pv_name>
+    <x>120</x>
     <y>175</y>
     <width>120</width>
     <height>20</height>
@@ -332,10 +333,10 @@
   </widget>
   <widget type="label" version="2.0.0">
     <name>text #70</name>
-    <text>Dead Time Corr</text>
+    <text>Erase on Start?</text>
     <x>5</x>
     <y>180</y>
-    <width>150</width>
+    <width>110</width>
     <height>15</height>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
@@ -578,31 +579,8 @@
   </widget>
   <widget type="textupdate" version="2.0.0">
     <name>text update #118</name>
-    <pv_name>$(P):det1:CTRL_DTC_RBV</pv_name>
-    <x>280</x>
-    <y>175</y>
-    <width>120</width>
-    <height>15</height>
-    <font>
-      <font family="Liberation Sans" style="REGULAR" size="16.0">
-      </font>
-    </font>
-    <foreground_color>
-      <color red="10" green="0" blue="184">
-      </color>
-    </foreground_color>
-    <background_color>
-      <color red="255" green="255" blue="255">
-      </color>
-    </background_color>
-    <format>1</format>
-    <show_units>false</show_units>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-  </widget>
-  <widget type="textupdate" version="2.0.0">
-    <name>text update #122</name>
     <pv_name>$(P):det1:TriggerMode_RBV</pv_name>
-    <x>285</x>
+    <x>270</x>
     <y>210</y>
     <width>120</width>
     <height>15</height>
@@ -623,9 +601,9 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #126</name>
+    <name>menu #122</name>
     <pv_name>$(P):det1:TriggerMode</pv_name>
-    <x>155</x>
+    <x>120</x>
     <y>210</y>
     <width>120</width>
     <height>20</height>
@@ -640,10 +618,11 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #129</name>
+    <name>text #125</name>
     <text>Dwell Time</text>
     <x>5</x>
     <y>150</y>
+    <width>80</width>
     <height>15</height>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
@@ -652,10 +631,11 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #132</name>
+    <name>text entry #128</name>
     <pv_name>$(P):det1:AcquireTime</pv_name>
-    <x>102</x>
+    <x>120</x>
     <y>145</y>
+    <width>80</width>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
       </font>
@@ -669,7 +649,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #136</name>
+    <name>text update #132</name>
     <pv_name>$(P):det1:AcquireTime_RBV</pv_name>
     <x>210</x>
     <y>145</y>
@@ -692,7 +672,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #140</name>
+    <name>text #136</name>
     <text>Control &amp; Status</text>
     <x>10</x>
     <y>59</y>
@@ -704,7 +684,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #143</name>
+    <name>text #139</name>
     <text>HDF5 File Saving</text>
     <x>5</x>
     <y>250</y>
@@ -716,7 +696,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #146</name>
+    <name>text #142</name>
     <text>File Path</text>
     <x>10</x>
     <y>318</y>
@@ -724,7 +704,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #149</name>
+    <name>text #145</name>
     <text>Capturing</text>
     <x>335</x>
     <y>250</y>
@@ -737,7 +717,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #152</name>
+    <name>text #148</name>
     <text>Status</text>
     <x>10</x>
     <y>491</y>
@@ -746,7 +726,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #155</name>
+    <name>text update #151</name>
     <pv_name>$(P):HDF1:WriteMessage</pv_name>
     <x>100</x>
     <y>491</y>
@@ -769,7 +749,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #159</name>
+    <name>text update #155</name>
     <pv_name>$(P):det1:StatusMessage_RBV</pv_name>
     <x>170</x>
     <y>5</y>
@@ -792,7 +772,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #163</name>
+    <name>text #159</name>
     <text>Frames Saved</text>
     <x>10</x>
     <y>441</y>
@@ -801,7 +781,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #166</name>
+    <name>text update #162</name>
     <pv_name>$(P):HDF1:NumCaptured_RBV</pv_name>
     <x>100</x>
     <y>441</y>
@@ -823,7 +803,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #170</name>
+    <name>text #166</name>
     <text>Compression</text>
     <x>10</x>
     <y>406</y>
@@ -831,7 +811,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #173</name>
+    <name>menu #169</name>
     <pv_name>$(P):HDF1:Compression</pv_name>
     <x>100</x>
     <y>404</y>
@@ -847,7 +827,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #176</name>
+    <name>text #172</name>
     <text>ZLevel:</text>
     <x>230</x>
     <y>406</y>
@@ -856,7 +836,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #179</name>
+    <name>text entry #175</name>
     <pv_name>$(P):HDF1:ZLevel</pv_name>
     <x>320</x>
     <y>406</y>
@@ -873,7 +853,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #183</name>
+    <name>text #179</name>
     <text>Last File</text>
     <x>10</x>
     <y>466</y>
@@ -881,7 +861,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #186</name>
+    <name>text update #182</name>
     <pv_name>$(P):HDF1:FullFileName_RBV</pv_name>
     <x>100</x>
     <y>466</y>
@@ -904,7 +884,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #190</name>
+    <name>text #186</name>
     <text>File Format</text>
     <x>10</x>
     <y>376</y>
@@ -913,7 +893,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #193</name>
+    <name>text entry #189</name>
     <pv_name>$(P):HDF1:FileTemplate</pv_name>
     <x>100</x>
     <y>376</y>
@@ -931,7 +911,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #197</name>
+    <name>text #193</name>
     <text>Auto Number</text>
     <x>230</x>
     <y>376</y>
@@ -940,7 +920,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #200</name>
+    <name>menu #196</name>
     <pv_name>$(P):HDF1:AutoIncrement</pv_name>
     <x>320</x>
     <y>375</y>
@@ -956,7 +936,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #203</name>
+    <name>related display #199</name>
     <actions>
       <action type="open_display">
         <file>xspress3_mcarois.opi</file>
@@ -982,7 +962,7 @@
     </background_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #206</name>
+    <name>related display #202</name>
     <actions>
       <action type="open_display">
         <file>xspress3_mcarois.opi</file>

--- a/xspress3App/opi/bob/xspress3_4chan.bob
+++ b/xspress3App/opi/bob/xspress3_4chan.bob
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <display version="2.0.0">
   <name>xspress3_4chan</name>
-  <x>207</x>
-  <y>68</y>
+  <x>400</x>
+  <y>250</y>
   <width>450</width>
   <height>525</height>
   <background_color>
@@ -299,8 +299,9 @@
   <widget type="textentry" version="3.0.0">
     <name>text entry #63</name>
     <pv_name>$(P):det1:NumImages</pv_name>
-    <x>102</x>
+    <x>120</x>
     <y>120</y>
+    <width>80</width>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
       </font>
@@ -313,38 +314,8 @@
     <show_units>false</show_units>
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
-  <widget type="choice" version="2.0.0">
-    <name>choice button #67</name>
-    <pv_name>$(P):det1:CTRL_DTC</pv_name>
-    <x>155</x>
-    <y>175</y>
-    <width>120</width>
-    <height>20</height>
-    <background_color>
-      <color red="200" green="200" blue="200">
-      </color>
-    </background_color>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <items>
-      <item>Item 1</item>
-      <item>Item 2</item>
-    </items>
-  </widget>
   <widget type="label" version="2.0.0">
-    <name>text #70</name>
-    <text>Dead Time Corr</text>
-    <x>5</x>
-    <y>180</y>
-    <width>150</width>
-    <height>15</height>
-    <font>
-      <font family="Liberation Sans" style="REGULAR" size="16.0">
-      </font>
-    </font>
-    <auto_size>true</auto_size>
-  </widget>
-  <widget type="label" version="2.0.0">
-    <name>text #73</name>
+    <name>text #67</name>
     <text>Trigger</text>
     <x>5</x>
     <y>215</y>
@@ -352,7 +323,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #76</name>
+    <name>text entry #70</name>
     <pv_name>$(P):HDF1:FilePath</pv_name>
     <x>100</x>
     <y>315</y>
@@ -370,7 +341,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #80</name>
+    <name>text #74</name>
     <text>File Prefix</text>
     <x>10</x>
     <y>348</y>
@@ -378,7 +349,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #83</name>
+    <name>text entry #77</name>
     <pv_name>$(P):HDF1:FileName</pv_name>
     <x>100</x>
     <y>345</y>
@@ -396,7 +367,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #87</name>
+    <name>text #81</name>
     <text>File Number</text>
     <x>230</x>
     <y>348</y>
@@ -405,7 +376,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #90</name>
+    <name>text entry #84</name>
     <pv_name>$(P):HDF1:FileNumber</pv_name>
     <x>320</x>
     <y>346</y>
@@ -422,7 +393,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
-    <name>bar #94</name>
+    <name>bar #88</name>
     <pv_name>$(P):HDF1:FilePathExists_RBV</pv_name>
     <x>425</x>
     <y>315</y>
@@ -436,7 +407,7 @@
     </foreground_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>message button #97</name>
+    <name>message button #91</name>
     <actions>
       <action type="write_pv">
         <pv_name>$(P):HDF1:Capture</pv_name>
@@ -459,7 +430,7 @@
     </background_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>message button #100</name>
+    <name>message button #94</name>
     <actions>
       <action type="write_pv">
         <pv_name>$(P):HDF1:Capture</pv_name>
@@ -482,7 +453,7 @@
     </background_color>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
-    <name>bar #103</name>
+    <name>bar #97</name>
     <pv_name>$(P):HDF1:Capture_RBV</pv_name>
     <x>420</x>
     <y>250</y>
@@ -496,7 +467,7 @@
     </foreground_color>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
-    <name>bar #106</name>
+    <name>bar #100</name>
     <pv_name>$(P):HDF1:WriteStatus</pv_name>
     <x>425</x>
     <y>491</y>
@@ -510,7 +481,7 @@
     </foreground_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #109</name>
+    <name>related display #103</name>
     <actions>
       <action type="open_display">
         <file>ADBase.opi</file>
@@ -554,7 +525,7 @@
     </background_color>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #114</name>
+    <name>text update #108</name>
     <pv_name>$(P):det1:NumImages_RBV</pv_name>
     <x>210</x>
     <y>120</y>
@@ -577,32 +548,9 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #118</name>
-    <pv_name>$(P):det1:CTRL_DTC_RBV</pv_name>
-    <x>280</x>
-    <y>175</y>
-    <width>120</width>
-    <height>15</height>
-    <font>
-      <font family="Liberation Sans" style="REGULAR" size="16.0">
-      </font>
-    </font>
-    <foreground_color>
-      <color red="10" green="0" blue="184">
-      </color>
-    </foreground_color>
-    <background_color>
-      <color red="255" green="255" blue="255">
-      </color>
-    </background_color>
-    <format>1</format>
-    <show_units>false</show_units>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-  </widget>
-  <widget type="textupdate" version="2.0.0">
-    <name>text update #122</name>
+    <name>text update #112</name>
     <pv_name>$(P):det1:TriggerMode_RBV</pv_name>
-    <x>285</x>
+    <x>270</x>
     <y>210</y>
     <width>120</width>
     <height>15</height>
@@ -623,9 +571,9 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #126</name>
+    <name>menu #116</name>
     <pv_name>$(P):det1:TriggerMode</pv_name>
-    <x>155</x>
+    <x>120</x>
     <y>210</y>
     <width>120</width>
     <height>20</height>
@@ -640,7 +588,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #129</name>
+    <name>text #119</name>
     <text>Dwell Time</text>
     <x>5</x>
     <y>150</y>
@@ -652,10 +600,11 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #132</name>
+    <name>text entry #122</name>
     <pv_name>$(P):det1:AcquireTime</pv_name>
-    <x>102</x>
+    <x>120</x>
     <y>145</y>
+    <width>80</width>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
       </font>
@@ -669,7 +618,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #136</name>
+    <name>text update #126</name>
     <pv_name>$(P):det1:AcquireTime_RBV</pv_name>
     <x>210</x>
     <y>145</y>
@@ -692,7 +641,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #140</name>
+    <name>text #130</name>
     <text>Control &amp; Status</text>
     <x>10</x>
     <y>59</y>
@@ -704,7 +653,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #143</name>
+    <name>text #133</name>
     <text>HDF5 File Saving</text>
     <x>5</x>
     <y>250</y>
@@ -716,7 +665,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #146</name>
+    <name>text #136</name>
     <text>File Path</text>
     <x>10</x>
     <y>318</y>
@@ -724,7 +673,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #149</name>
+    <name>text #139</name>
     <text>Capturing</text>
     <x>335</x>
     <y>250</y>
@@ -737,7 +686,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #152</name>
+    <name>text #142</name>
     <text>Status</text>
     <x>10</x>
     <y>491</y>
@@ -746,7 +695,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #155</name>
+    <name>text update #145</name>
     <pv_name>$(P):HDF1:WriteMessage</pv_name>
     <x>100</x>
     <y>491</y>
@@ -769,7 +718,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #159</name>
+    <name>text update #149</name>
     <pv_name>$(P):det1:StatusMessage_RBV</pv_name>
     <x>170</x>
     <y>5</y>
@@ -792,7 +741,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #163</name>
+    <name>text #153</name>
     <text>Frames Saved</text>
     <x>10</x>
     <y>441</y>
@@ -801,7 +750,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #166</name>
+    <name>text update #156</name>
     <pv_name>$(P):HDF1:NumCaptured_RBV</pv_name>
     <x>100</x>
     <y>441</y>
@@ -823,7 +772,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #170</name>
+    <name>text #160</name>
     <text>Compression</text>
     <x>10</x>
     <y>406</y>
@@ -831,7 +780,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #173</name>
+    <name>menu #163</name>
     <pv_name>$(P):HDF1:Compression</pv_name>
     <x>100</x>
     <y>404</y>
@@ -847,7 +796,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #176</name>
+    <name>text #166</name>
     <text>ZLevel:</text>
     <x>230</x>
     <y>406</y>
@@ -856,7 +805,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #179</name>
+    <name>text entry #169</name>
     <pv_name>$(P):HDF1:ZLevel</pv_name>
     <x>320</x>
     <y>406</y>
@@ -873,7 +822,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #183</name>
+    <name>text #173</name>
     <text>Last File</text>
     <x>10</x>
     <y>466</y>
@@ -881,7 +830,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #186</name>
+    <name>text update #176</name>
     <pv_name>$(P):HDF1:FullFileName_RBV</pv_name>
     <x>100</x>
     <y>466</y>
@@ -904,7 +853,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #190</name>
+    <name>text #180</name>
     <text>File Format</text>
     <x>10</x>
     <y>376</y>
@@ -913,7 +862,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #193</name>
+    <name>text entry #183</name>
     <pv_name>$(P):HDF1:FileTemplate</pv_name>
     <x>100</x>
     <y>376</y>
@@ -931,7 +880,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #197</name>
+    <name>text #187</name>
     <text>Auto Number</text>
     <x>230</x>
     <y>376</y>
@@ -940,7 +889,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #200</name>
+    <name>menu #190</name>
     <pv_name>$(P):HDF1:AutoIncrement</pv_name>
     <x>320</x>
     <y>375</y>
@@ -956,7 +905,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #203</name>
+    <name>related display #193</name>
     <actions>
       <action type="open_display">
         <file>xspress3_mcarois.opi</file>
@@ -982,7 +931,7 @@
     </background_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #206</name>
+    <name>related display #196</name>
     <actions>
       <action type="open_display">
         <file>xspress3_mcarois.opi</file>
@@ -1008,7 +957,7 @@
     </background_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #209</name>
+    <name>related display #199</name>
     <actions>
       <action type="open_display">
         <file>xspress3_mcarois.opi</file>
@@ -1034,7 +983,7 @@
     </background_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #212</name>
+    <name>related display #202</name>
     <actions>
       <action type="open_display">
         <file>xspress3_mcarois.opi</file>
@@ -1060,7 +1009,7 @@
     </background_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #215</name>
+    <name>related display #205</name>
     <actions>
       <action type="open_display">
         <file>xspress3_4mcas.opi</file>
@@ -1092,5 +1041,35 @@
       <color red="235" green="241" blue="181">
       </color>
     </background_color>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>text #209</name>
+    <text>Erase on Start?</text>
+    <x>5</x>
+    <y>180</y>
+    <width>110</width>
+    <height>15</height>
+    <font>
+      <font family="Liberation Sans" style="REGULAR" size="16.0">
+      </font>
+    </font>
+    <auto_size>true</auto_size>
+  </widget>
+  <widget type="choice" version="2.0.0">
+    <name>choice button #212</name>
+    <pv_name>$(P):det1:EraseOnStart</pv_name>
+    <x>120</x>
+    <y>175</y>
+    <width>120</width>
+    <height>20</height>
+    <background_color>
+      <color red="200" green="200" blue="200">
+      </color>
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <items>
+      <item>Item 1</item>
+      <item>Item 2</item>
+    </items>
   </widget>
 </display>

--- a/xspress3App/opi/bob/xspress3_7chan.bob
+++ b/xspress3App/opi/bob/xspress3_7chan.bob
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <display version="2.0.0">
   <name>xspress3_7chan</name>
-  <x>690</x>
-  <y>186</y>
+  <x>400</x>
+  <y>250</y>
   <width>450</width>
   <height>525</height>
   <background_color>
@@ -299,8 +299,9 @@
   <widget type="textentry" version="3.0.0">
     <name>text entry #63</name>
     <pv_name>$(P):det1:NumImages</pv_name>
-    <x>102</x>
+    <x>120</x>
     <y>120</y>
+    <width>80</width>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
       </font>
@@ -313,38 +314,8 @@
     <show_units>false</show_units>
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
-  <widget type="choice" version="2.0.0">
-    <name>choice button #67</name>
-    <pv_name>$(P):det1:CTRL_DTC</pv_name>
-    <x>155</x>
-    <y>175</y>
-    <width>120</width>
-    <height>20</height>
-    <background_color>
-      <color red="200" green="200" blue="200">
-      </color>
-    </background_color>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <items>
-      <item>Item 1</item>
-      <item>Item 2</item>
-    </items>
-  </widget>
   <widget type="label" version="2.0.0">
-    <name>text #70</name>
-    <text>Dead Time Corr</text>
-    <x>5</x>
-    <y>180</y>
-    <width>150</width>
-    <height>15</height>
-    <font>
-      <font family="Liberation Sans" style="REGULAR" size="16.0">
-      </font>
-    </font>
-    <auto_size>true</auto_size>
-  </widget>
-  <widget type="label" version="2.0.0">
-    <name>text #73</name>
+    <name>text #67</name>
     <text>Trigger</text>
     <x>5</x>
     <y>215</y>
@@ -352,7 +323,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #76</name>
+    <name>text entry #70</name>
     <pv_name>$(P):HDF1:FilePath</pv_name>
     <x>100</x>
     <y>315</y>
@@ -370,7 +341,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #80</name>
+    <name>text #74</name>
     <text>File Prefix</text>
     <x>10</x>
     <y>348</y>
@@ -378,7 +349,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #83</name>
+    <name>text entry #77</name>
     <pv_name>$(P):HDF1:FileName</pv_name>
     <x>100</x>
     <y>345</y>
@@ -396,7 +367,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #87</name>
+    <name>text #81</name>
     <text>File Number</text>
     <x>230</x>
     <y>348</y>
@@ -405,7 +376,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #90</name>
+    <name>text entry #84</name>
     <pv_name>$(P):HDF1:FileNumber</pv_name>
     <x>320</x>
     <y>346</y>
@@ -422,7 +393,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
-    <name>bar #94</name>
+    <name>bar #88</name>
     <pv_name>$(P):HDF1:FilePathExists_RBV</pv_name>
     <x>425</x>
     <y>315</y>
@@ -436,7 +407,7 @@
     </foreground_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>message button #97</name>
+    <name>message button #91</name>
     <actions>
       <action type="write_pv">
         <pv_name>$(P):HDF1:Capture</pv_name>
@@ -459,7 +430,7 @@
     </background_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>message button #100</name>
+    <name>message button #94</name>
     <actions>
       <action type="write_pv">
         <pv_name>$(P):HDF1:Capture</pv_name>
@@ -482,7 +453,7 @@
     </background_color>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
-    <name>bar #103</name>
+    <name>bar #97</name>
     <pv_name>$(P):HDF1:Capture_RBV</pv_name>
     <x>420</x>
     <y>250</y>
@@ -496,7 +467,7 @@
     </foreground_color>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
-    <name>bar #106</name>
+    <name>bar #100</name>
     <pv_name>$(P):HDF1:WriteStatus</pv_name>
     <x>425</x>
     <y>491</y>
@@ -510,7 +481,7 @@
     </foreground_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #109</name>
+    <name>related display #103</name>
     <actions>
       <action type="open_display">
         <file>ADBase.opi</file>
@@ -554,7 +525,7 @@
     </background_color>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #114</name>
+    <name>text update #108</name>
     <pv_name>$(P):det1:NumImages_RBV</pv_name>
     <x>210</x>
     <y>120</y>
@@ -577,32 +548,9 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #118</name>
-    <pv_name>$(P):det1:CTRL_DTC_RBV</pv_name>
-    <x>280</x>
-    <y>175</y>
-    <width>120</width>
-    <height>15</height>
-    <font>
-      <font family="Liberation Sans" style="REGULAR" size="16.0">
-      </font>
-    </font>
-    <foreground_color>
-      <color red="10" green="0" blue="184">
-      </color>
-    </foreground_color>
-    <background_color>
-      <color red="255" green="255" blue="255">
-      </color>
-    </background_color>
-    <format>1</format>
-    <show_units>false</show_units>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-  </widget>
-  <widget type="textupdate" version="2.0.0">
-    <name>text update #122</name>
+    <name>text update #112</name>
     <pv_name>$(P):det1:TriggerMode_RBV</pv_name>
-    <x>285</x>
+    <x>270</x>
     <y>210</y>
     <width>120</width>
     <height>15</height>
@@ -623,9 +571,9 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #126</name>
+    <name>menu #116</name>
     <pv_name>$(P):det1:TriggerMode</pv_name>
-    <x>155</x>
+    <x>120</x>
     <y>210</y>
     <width>120</width>
     <height>20</height>
@@ -640,7 +588,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #129</name>
+    <name>text #119</name>
     <text>Dwell Time</text>
     <x>5</x>
     <y>150</y>
@@ -652,10 +600,11 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #132</name>
+    <name>text entry #122</name>
     <pv_name>$(P):det1:AcquireTime</pv_name>
-    <x>102</x>
+    <x>120</x>
     <y>145</y>
+    <width>80</width>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
       </font>
@@ -669,7 +618,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #136</name>
+    <name>text update #126</name>
     <pv_name>$(P):det1:AcquireTime_RBV</pv_name>
     <x>210</x>
     <y>145</y>
@@ -692,7 +641,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #140</name>
+    <name>text #130</name>
     <text>Control &amp; Status</text>
     <x>10</x>
     <y>59</y>
@@ -704,7 +653,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #143</name>
+    <name>text #133</name>
     <text>HDF5 File Saving</text>
     <x>5</x>
     <y>250</y>
@@ -716,7 +665,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #146</name>
+    <name>text #136</name>
     <text>File Path</text>
     <x>10</x>
     <y>318</y>
@@ -724,7 +673,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #149</name>
+    <name>text #139</name>
     <text>Capturing</text>
     <x>335</x>
     <y>250</y>
@@ -737,7 +686,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #152</name>
+    <name>text #142</name>
     <text>Status</text>
     <x>10</x>
     <y>491</y>
@@ -746,7 +695,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #155</name>
+    <name>text update #145</name>
     <pv_name>$(P):HDF1:WriteMessage</pv_name>
     <x>100</x>
     <y>491</y>
@@ -769,7 +718,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #159</name>
+    <name>text update #149</name>
     <pv_name>$(P):det1:StatusMessage_RBV</pv_name>
     <x>170</x>
     <y>5</y>
@@ -792,7 +741,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #163</name>
+    <name>text #153</name>
     <text>Frames Saved</text>
     <x>10</x>
     <y>441</y>
@@ -801,7 +750,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #166</name>
+    <name>text update #156</name>
     <pv_name>$(P):HDF1:NumCaptured_RBV</pv_name>
     <x>100</x>
     <y>441</y>
@@ -823,7 +772,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #170</name>
+    <name>text #160</name>
     <text>Compression</text>
     <x>10</x>
     <y>406</y>
@@ -831,7 +780,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #173</name>
+    <name>menu #163</name>
     <pv_name>$(P):HDF1:Compression</pv_name>
     <x>100</x>
     <y>404</y>
@@ -847,7 +796,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #176</name>
+    <name>text #166</name>
     <text>ZLevel:</text>
     <x>230</x>
     <y>406</y>
@@ -856,7 +805,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #179</name>
+    <name>text entry #169</name>
     <pv_name>$(P):HDF1:ZLevel</pv_name>
     <x>320</x>
     <y>406</y>
@@ -873,7 +822,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #183</name>
+    <name>text #173</name>
     <text>Last File</text>
     <x>10</x>
     <y>466</y>
@@ -881,7 +830,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #186</name>
+    <name>text update #176</name>
     <pv_name>$(P):HDF1:FullFileName_RBV</pv_name>
     <x>100</x>
     <y>466</y>
@@ -904,7 +853,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #190</name>
+    <name>text #180</name>
     <text>File Format</text>
     <x>10</x>
     <y>376</y>
@@ -913,7 +862,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #193</name>
+    <name>text entry #183</name>
     <pv_name>$(P):HDF1:FileTemplate</pv_name>
     <x>100</x>
     <y>376</y>
@@ -931,7 +880,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #197</name>
+    <name>text #187</name>
     <text>Auto Number</text>
     <x>230</x>
     <y>376</y>
@@ -940,7 +889,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #200</name>
+    <name>menu #190</name>
     <pv_name>$(P):HDF1:AutoIncrement</pv_name>
     <x>320</x>
     <y>375</y>
@@ -956,7 +905,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #203</name>
+    <name>related display #193</name>
     <actions>
       <action type="open_display">
         <file>xspress3_mcarois.opi</file>
@@ -1029,7 +978,7 @@
     </background_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #212</name>
+    <name>related display #202</name>
     <actions>
       <action type="open_display">
         <file>xspress3_7mcas_me7.opi</file>
@@ -1077,5 +1026,35 @@
       <color red="235" green="241" blue="181">
       </color>
     </background_color>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>text #208</name>
+    <text>Erase on Start?</text>
+    <x>5</x>
+    <y>180</y>
+    <width>110</width>
+    <height>15</height>
+    <font>
+      <font family="Liberation Sans" style="REGULAR" size="16.0">
+      </font>
+    </font>
+    <auto_size>true</auto_size>
+  </widget>
+  <widget type="choice" version="2.0.0">
+    <name>choice button #211</name>
+    <pv_name>$(P):det1:EraseOnStart</pv_name>
+    <x>120</x>
+    <y>175</y>
+    <width>120</width>
+    <height>20</height>
+    <background_color>
+      <color red="200" green="200" blue="200">
+      </color>
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <items>
+      <item>Item 1</item>
+      <item>Item 2</item>
+    </items>
   </widget>
 </display>

--- a/xspress3App/opi/bob/xspress3_8chan.bob
+++ b/xspress3App/opi/bob/xspress3_8chan.bob
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <display version="2.0.0">
   <name>xspress3_8chan</name>
-  <x>690</x>
-  <y>186</y>
+  <x>400</x>
+  <y>250</y>
   <width>450</width>
   <height>525</height>
   <background_color>
@@ -299,8 +299,9 @@
   <widget type="textentry" version="3.0.0">
     <name>text entry #63</name>
     <pv_name>$(P):det1:NumImages</pv_name>
-    <x>102</x>
+    <x>120</x>
     <y>120</y>
+    <width>80</width>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
       </font>
@@ -313,38 +314,8 @@
     <show_units>false</show_units>
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
-  <widget type="choice" version="2.0.0">
-    <name>choice button #67</name>
-    <pv_name>$(P):det1:CTRL_DTC</pv_name>
-    <x>155</x>
-    <y>175</y>
-    <width>120</width>
-    <height>20</height>
-    <background_color>
-      <color red="200" green="200" blue="200">
-      </color>
-    </background_color>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <items>
-      <item>Item 1</item>
-      <item>Item 2</item>
-    </items>
-  </widget>
   <widget type="label" version="2.0.0">
-    <name>text #70</name>
-    <text>Dead Time Corr</text>
-    <x>5</x>
-    <y>180</y>
-    <width>150</width>
-    <height>15</height>
-    <font>
-      <font family="Liberation Sans" style="REGULAR" size="16.0">
-      </font>
-    </font>
-    <auto_size>true</auto_size>
-  </widget>
-  <widget type="label" version="2.0.0">
-    <name>text #73</name>
+    <name>text #67</name>
     <text>Trigger</text>
     <x>5</x>
     <y>215</y>
@@ -352,7 +323,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #76</name>
+    <name>text entry #70</name>
     <pv_name>$(P):HDF1:FilePath</pv_name>
     <x>100</x>
     <y>315</y>
@@ -370,7 +341,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #80</name>
+    <name>text #74</name>
     <text>File Prefix</text>
     <x>10</x>
     <y>348</y>
@@ -378,7 +349,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #83</name>
+    <name>text entry #77</name>
     <pv_name>$(P):HDF1:FileName</pv_name>
     <x>100</x>
     <y>345</y>
@@ -396,7 +367,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #87</name>
+    <name>text #81</name>
     <text>File Number</text>
     <x>230</x>
     <y>348</y>
@@ -405,7 +376,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #90</name>
+    <name>text entry #84</name>
     <pv_name>$(P):HDF1:FileNumber</pv_name>
     <x>320</x>
     <y>346</y>
@@ -422,7 +393,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
-    <name>bar #94</name>
+    <name>bar #88</name>
     <pv_name>$(P):HDF1:FilePathExists_RBV</pv_name>
     <x>425</x>
     <y>315</y>
@@ -436,7 +407,7 @@
     </foreground_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>message button #97</name>
+    <name>message button #91</name>
     <actions>
       <action type="write_pv">
         <pv_name>$(P):HDF1:Capture</pv_name>
@@ -459,7 +430,7 @@
     </background_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>message button #100</name>
+    <name>message button #94</name>
     <actions>
       <action type="write_pv">
         <pv_name>$(P):HDF1:Capture</pv_name>
@@ -482,7 +453,7 @@
     </background_color>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
-    <name>bar #103</name>
+    <name>bar #97</name>
     <pv_name>$(P):HDF1:Capture_RBV</pv_name>
     <x>420</x>
     <y>250</y>
@@ -496,7 +467,7 @@
     </foreground_color>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
-    <name>bar #106</name>
+    <name>bar #100</name>
     <pv_name>$(P):HDF1:WriteStatus</pv_name>
     <x>425</x>
     <y>491</y>
@@ -510,7 +481,7 @@
     </foreground_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #109</name>
+    <name>related display #103</name>
     <actions>
       <action type="open_display">
         <file>ADBase.opi</file>
@@ -558,7 +529,7 @@
     </background_color>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #115</name>
+    <name>text update #109</name>
     <pv_name>$(P):det1:NumImages_RBV</pv_name>
     <x>210</x>
     <y>120</y>
@@ -581,32 +552,9 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #119</name>
-    <pv_name>$(P):det1:CTRL_DTC_RBV</pv_name>
-    <x>280</x>
-    <y>175</y>
-    <width>120</width>
-    <height>15</height>
-    <font>
-      <font family="Liberation Sans" style="REGULAR" size="16.0">
-      </font>
-    </font>
-    <foreground_color>
-      <color red="10" green="0" blue="184">
-      </color>
-    </foreground_color>
-    <background_color>
-      <color red="255" green="255" blue="255">
-      </color>
-    </background_color>
-    <format>1</format>
-    <show_units>false</show_units>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-  </widget>
-  <widget type="textupdate" version="2.0.0">
-    <name>text update #123</name>
+    <name>text update #113</name>
     <pv_name>$(P):det1:TriggerMode_RBV</pv_name>
-    <x>285</x>
+    <x>270</x>
     <y>210</y>
     <width>120</width>
     <height>15</height>
@@ -627,9 +575,9 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #127</name>
+    <name>menu #117</name>
     <pv_name>$(P):det1:TriggerMode</pv_name>
-    <x>155</x>
+    <x>120</x>
     <y>210</y>
     <width>120</width>
     <height>20</height>
@@ -644,7 +592,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #130</name>
+    <name>text #120</name>
     <text>Dwell Time</text>
     <x>5</x>
     <y>150</y>
@@ -656,10 +604,11 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #133</name>
+    <name>text entry #123</name>
     <pv_name>$(P):det1:AcquireTime</pv_name>
-    <x>102</x>
+    <x>120</x>
     <y>145</y>
+    <width>80</width>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
       </font>
@@ -673,7 +622,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #137</name>
+    <name>text update #127</name>
     <pv_name>$(P):det1:AcquireTime_RBV</pv_name>
     <x>210</x>
     <y>145</y>
@@ -696,7 +645,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #141</name>
+    <name>text #131</name>
     <text>Control &amp; Status</text>
     <x>10</x>
     <y>59</y>
@@ -708,7 +657,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #144</name>
+    <name>text #134</name>
     <text>HDF5 File Saving</text>
     <x>5</x>
     <y>250</y>
@@ -720,7 +669,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #147</name>
+    <name>text #137</name>
     <text>File Path</text>
     <x>10</x>
     <y>318</y>
@@ -728,7 +677,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #150</name>
+    <name>text #140</name>
     <text>Capturing</text>
     <x>335</x>
     <y>250</y>
@@ -741,7 +690,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #153</name>
+    <name>text #143</name>
     <text>Status</text>
     <x>10</x>
     <y>491</y>
@@ -750,7 +699,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #156</name>
+    <name>text update #146</name>
     <pv_name>$(P):HDF1:WriteMessage</pv_name>
     <x>100</x>
     <y>491</y>
@@ -773,7 +722,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #160</name>
+    <name>text update #150</name>
     <pv_name>$(P):det1:StatusMessage_RBV</pv_name>
     <x>170</x>
     <y>5</y>
@@ -796,7 +745,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #164</name>
+    <name>text #154</name>
     <text>Frames Saved</text>
     <x>10</x>
     <y>441</y>
@@ -805,7 +754,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #167</name>
+    <name>text update #157</name>
     <pv_name>$(P):HDF1:NumCaptured_RBV</pv_name>
     <x>100</x>
     <y>441</y>
@@ -827,7 +776,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #171</name>
+    <name>text #161</name>
     <text>Compression</text>
     <x>10</x>
     <y>406</y>
@@ -835,7 +784,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #174</name>
+    <name>menu #164</name>
     <pv_name>$(P):HDF1:Compression</pv_name>
     <x>100</x>
     <y>404</y>
@@ -851,7 +800,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #177</name>
+    <name>text #167</name>
     <text>ZLevel:</text>
     <x>230</x>
     <y>406</y>
@@ -860,7 +809,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #180</name>
+    <name>text entry #170</name>
     <pv_name>$(P):HDF1:ZLevel</pv_name>
     <x>320</x>
     <y>406</y>
@@ -877,7 +826,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #184</name>
+    <name>text #174</name>
     <text>Last File</text>
     <x>10</x>
     <y>466</y>
@@ -885,7 +834,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #187</name>
+    <name>text update #177</name>
     <pv_name>$(P):HDF1:FullFileName_RBV</pv_name>
     <x>100</x>
     <y>466</y>
@@ -908,7 +857,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #191</name>
+    <name>text #181</name>
     <text>File Format</text>
     <x>10</x>
     <y>376</y>
@@ -917,7 +866,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #194</name>
+    <name>text entry #184</name>
     <pv_name>$(P):HDF1:FileTemplate</pv_name>
     <x>100</x>
     <y>376</y>
@@ -935,7 +884,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #198</name>
+    <name>text #188</name>
     <text>Auto Number</text>
     <x>230</x>
     <y>376</y>
@@ -944,7 +893,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #201</name>
+    <name>menu #191</name>
     <pv_name>$(P):HDF1:AutoIncrement</pv_name>
     <x>320</x>
     <y>375</y>
@@ -960,7 +909,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #204</name>
+    <name>related display #194</name>
     <actions>
       <action type="open_display">
         <file>xspress3_mcarois.opi</file>
@@ -1041,7 +990,7 @@
     </background_color>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>related display #214</name>
+    <name>related display #204</name>
     <actions>
       <action type="open_display">
         <file>xspress3_8mcas.opi</file>
@@ -1073,5 +1022,35 @@
       <color red="235" green="241" blue="181">
       </color>
     </background_color>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>text #208</name>
+    <text>Erase on Start?</text>
+    <x>5</x>
+    <y>180</y>
+    <width>110</width>
+    <height>15</height>
+    <font>
+      <font family="Liberation Sans" style="REGULAR" size="16.0">
+      </font>
+    </font>
+    <auto_size>true</auto_size>
+  </widget>
+  <widget type="choice" version="2.0.0">
+    <name>choice button #211</name>
+    <pv_name>$(P):det1:EraseOnStart</pv_name>
+    <x>120</x>
+    <y>175</y>
+    <width>120</width>
+    <height>20</height>
+    <background_color>
+      <color red="200" green="200" blue="200">
+      </color>
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <items>
+      <item>Item 1</item>
+      <item>Item 2</item>
+    </items>
   </widget>
 </display>

--- a/xspress3App/opi/edl/xspress3_14chan.edl
+++ b/xspress3App/opi/edl/xspress3_14chan.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 690
-y 186
+x 400
+y 250
 w 450
 h 525
 font "helvetica-medium-r-18.0"
@@ -326,9 +326,9 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 102
+x 120
 y 120
-w 100
+w 80
 h 20
 controlPv "$(P):det1:NumImages"
 format "decimal"
@@ -344,25 +344,6 @@ smartRefresh
 fastUpdate
 newPos
 objType "controls"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 5
-y 180
-w 150
-h 15
-font "helvetica-medium-r-12.0"
-fgColor rgb 0 0 0
-bgColor index 3
-useDisplayBg
-value {
-  "Dead Time Corr"
-}
 endObjectProperties
 
 # (Static Text)
@@ -587,31 +568,7 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 280
-y 175
-w 120
-h 15
-controlPv "$(P):det1:CTRL_DTC_RBV"
-format "decimal"
-font "helvetica-medium-r-12.0"
-fontAlign "left"
-fgColor rgb 2560 0 47104
-bgColor rgb 65280 65280 65280
-limitsFromDb
-nullColor rgb 60928 46592 11008
-smartRefresh
-fastUpdate
-newPos
-objType "controls"
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 7
-release 0
-x 285
+x 270
 y 210
 w 120
 h 15
@@ -654,9 +611,9 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 102
+x 120
 y 145
-w 100
+w 80
 h 20
 controlPv "$(P):det1:AcquireTime"
 format "decimal"
@@ -1055,6 +1012,25 @@ value {
 }
 endObjectProperties
 
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 5
+y 180
+w 110
+h 15
+font "helvetica-medium-r-12.0"
+fgColor rgb 0 0 0
+bgColor index 3
+useDisplayBg
+value {
+  "Erase on Start?"
+}
+endObjectProperties
+
 # (Message Button)
 object activeMessageButtonClass
 beginObjectProperties
@@ -1125,27 +1101,6 @@ onLabel "Stop"
 offLabel "Stop"
 3d
 font "helvetica-medium-r-14.0"
-endObjectProperties
-
-# (Choice Button)
-object activeChoiceButtonClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 155
-y 175
-w 120
-h 20
-fgColor rgb 0 0 0
-bgColor rgb 51200 51200 51200
-selectColor rgb 51200 51200 51200
-inconsistentColor rgb 0 0 0
-topShadowColor rgb 65280 65280 65280
-botShadowColor rgb 0 0 0
-controlPv "$(P):det1:CTRL_DTC"
-font "helvetica-medium-r-10.0"
-orientation "horizontal"
 endObjectProperties
 
 # (Message Button)
@@ -1246,7 +1201,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 155
+x 120
 y 210
 w 120
 h 20
@@ -1418,5 +1373,26 @@ replaceSymbols {
   0 1
   1 1
 }
+endObjectProperties
+
+# (Choice Button)
+object activeChoiceButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 120
+y 175
+w 120
+h 20
+fgColor rgb 0 0 0
+bgColor rgb 51200 51200 51200
+selectColor rgb 51200 51200 51200
+inconsistentColor rgb 0 0 0
+topShadowColor rgb 65280 65280 65280
+botShadowColor rgb 0 0 0
+controlPv "$(P):det1:EraseOnStart"
+font "helvetica-medium-r-10.0"
+orientation "horizontal"
 endObjectProperties
 

--- a/xspress3App/opi/edl/xspress3_16chan.edl
+++ b/xspress3App/opi/edl/xspress3_16chan.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 690
-y 186
+x 400
+y 250
 w 450
 h 525
 font "helvetica-medium-r-18.0"
@@ -326,9 +326,9 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 102
+x 120
 y 120
-w 100
+w 80
 h 20
 controlPv "$(P):det1:NumImages"
 format "decimal"
@@ -344,25 +344,6 @@ smartRefresh
 fastUpdate
 newPos
 objType "controls"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 5
-y 180
-w 150
-h 15
-font "helvetica-medium-r-12.0"
-fgColor rgb 0 0 0
-bgColor index 3
-useDisplayBg
-value {
-  "Dead Time Corr"
-}
 endObjectProperties
 
 # (Static Text)
@@ -587,31 +568,7 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 280
-y 175
-w 120
-h 15
-controlPv "$(P):det1:CTRL_DTC_RBV"
-format "decimal"
-font "helvetica-medium-r-12.0"
-fontAlign "left"
-fgColor rgb 2560 0 47104
-bgColor rgb 65280 65280 65280
-limitsFromDb
-nullColor rgb 60928 46592 11008
-smartRefresh
-fastUpdate
-newPos
-objType "controls"
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 7
-release 0
-x 285
+x 270
 y 210
 w 120
 h 15
@@ -654,9 +611,9 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 102
+x 120
 y 145
-w 100
+w 80
 h 20
 controlPv "$(P):det1:AcquireTime"
 format "decimal"
@@ -1055,6 +1012,25 @@ value {
 }
 endObjectProperties
 
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 5
+y 180
+w 110
+h 15
+font "helvetica-medium-r-12.0"
+fgColor rgb 0 0 0
+bgColor index 3
+useDisplayBg
+value {
+  "Erase on Start?"
+}
+endObjectProperties
+
 # (Message Button)
 object activeMessageButtonClass
 beginObjectProperties
@@ -1125,27 +1101,6 @@ onLabel "Stop"
 offLabel "Stop"
 3d
 font "helvetica-medium-r-14.0"
-endObjectProperties
-
-# (Choice Button)
-object activeChoiceButtonClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 155
-y 175
-w 120
-h 20
-fgColor rgb 0 0 0
-bgColor rgb 51200 51200 51200
-selectColor rgb 51200 51200 51200
-inconsistentColor rgb 0 0 0
-topShadowColor rgb 65280 65280 65280
-botShadowColor rgb 0 0 0
-controlPv "$(P):det1:CTRL_DTC"
-font "helvetica-medium-r-10.0"
-orientation "horizontal"
 endObjectProperties
 
 # (Message Button)
@@ -1246,7 +1201,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 155
+x 120
 y 210
 w 120
 h 20
@@ -1426,5 +1381,26 @@ replaceSymbols {
   0 1
   1 1
 }
+endObjectProperties
+
+# (Choice Button)
+object activeChoiceButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 120
+y 175
+w 120
+h 20
+fgColor rgb 0 0 0
+bgColor rgb 51200 51200 51200
+selectColor rgb 51200 51200 51200
+inconsistentColor rgb 0 0 0
+topShadowColor rgb 65280 65280 65280
+botShadowColor rgb 0 0 0
+controlPv "$(P):det1:EraseOnStart"
+font "helvetica-medium-r-10.0"
+orientation "horizontal"
 endObjectProperties
 

--- a/xspress3App/opi/edl/xspress3_1chan.edl
+++ b/xspress3App/opi/edl/xspress3_1chan.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 207
-y 68
+x 400
+y 250
 w 450
 h 525
 font "helvetica-medium-r-18.0"
@@ -188,7 +188,7 @@ major 4
 minor 7
 release 0
 x 360
-y 140
+y 145
 w 75
 h 15
 controlPv "$(P):det1:ArrayRate_RBV"
@@ -251,7 +251,7 @@ major 4
 minor 1
 release 1
 x 300
-y 140
+y 145
 w 50
 h 15
 font "helvetica-medium-r-12.0"
@@ -288,9 +288,9 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 102
+x 120
 y 120
-w 100
+w 80
 h 20
 controlPv "$(P):det1:NumImages"
 format "decimal"
@@ -316,14 +316,14 @@ minor 1
 release 1
 x 5
 y 180
-w 150
+w 110
 h 15
 font "helvetica-medium-r-12.0"
 fgColor rgb 0 0 0
 bgColor index 3
 useDisplayBg
 value {
-  "Dead Time Corr"
+  "Erase on Start?"
 }
 endObjectProperties
 
@@ -549,31 +549,7 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 280
-y 175
-w 120
-h 15
-controlPv "$(P):det1:CTRL_DTC_RBV"
-format "decimal"
-font "helvetica-medium-r-12.0"
-fontAlign "left"
-fgColor rgb 2560 0 47104
-bgColor rgb 65280 65280 65280
-limitsFromDb
-nullColor rgb 60928 46592 11008
-smartRefresh
-fastUpdate
-newPos
-objType "controls"
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 7
-release 0
-x 285
+x 270
 y 210
 w 120
 h 15
@@ -616,9 +592,9 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 102
+x 120
 y 145
-w 100
+w 80
 h 20
 controlPv "$(P):det1:AcquireTime"
 format "decimal"
@@ -1133,7 +1109,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 155
+x 120
 y 175
 w 120
 h 20
@@ -1143,7 +1119,7 @@ selectColor rgb 51200 51200 51200
 inconsistentColor rgb 0 0 0
 topShadowColor rgb 65280 65280 65280
 botShadowColor rgb 0 0 0
-controlPv "$(P):det1:CTRL_DTC"
+controlPv "$(P):det1:EraseOnStart"
 font "helvetica-medium-r-10.0"
 orientation "horizontal"
 endObjectProperties
@@ -1242,7 +1218,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 155
+x 120
 y 210
 w 120
 h 20

--- a/xspress3App/opi/edl/xspress3_2chan.edl
+++ b/xspress3App/opi/edl/xspress3_2chan.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 207
-y 68
+x 400
+y 250
 w 450
 h 525
 font "helvetica-medium-r-18.0"
@@ -188,7 +188,7 @@ major 4
 minor 7
 release 0
 x 360
-y 140
+y 145
 w 75
 h 15
 controlPv "$(P):det1:ArrayRate_RBV"
@@ -251,7 +251,7 @@ major 4
 minor 1
 release 1
 x 300
-y 140
+y 145
 w 50
 h 15
 font "helvetica-medium-r-12.0"
@@ -326,9 +326,9 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 102
+x 120
 y 120
-w 100
+w 80
 h 20
 controlPv "$(P):det1:NumImages"
 format "decimal"
@@ -354,14 +354,14 @@ minor 1
 release 1
 x 5
 y 180
-w 150
+w 110
 h 15
 font "helvetica-medium-r-12.0"
 fgColor rgb 0 0 0
 bgColor index 3
 useDisplayBg
 value {
-  "Dead Time Corr"
+  "Erase on Start?"
 }
 endObjectProperties
 
@@ -587,31 +587,7 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 280
-y 175
-w 120
-h 15
-controlPv "$(P):det1:CTRL_DTC_RBV"
-format "decimal"
-font "helvetica-medium-r-12.0"
-fontAlign "left"
-fgColor rgb 2560 0 47104
-bgColor rgb 65280 65280 65280
-limitsFromDb
-nullColor rgb 60928 46592 11008
-smartRefresh
-fastUpdate
-newPos
-objType "controls"
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 7
-release 0
-x 285
+x 270
 y 210
 w 120
 h 15
@@ -637,7 +613,7 @@ minor 1
 release 1
 x 5
 y 150
-w 100
+w 80
 h 15
 font "helvetica-medium-r-12.0"
 fgColor rgb 0 0 0
@@ -654,9 +630,9 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 102
+x 120
 y 145
-w 100
+w 80
 h 20
 controlPv "$(P):det1:AcquireTime"
 format "decimal"
@@ -1133,7 +1109,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 155
+x 120
 y 175
 w 120
 h 20
@@ -1143,7 +1119,7 @@ selectColor rgb 51200 51200 51200
 inconsistentColor rgb 0 0 0
 topShadowColor rgb 65280 65280 65280
 botShadowColor rgb 0 0 0
-controlPv "$(P):det1:CTRL_DTC"
+controlPv "$(P):det1:EraseOnStart"
 font "helvetica-medium-r-10.0"
 orientation "horizontal"
 endObjectProperties
@@ -1242,7 +1218,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 155
+x 120
 y 210
 w 120
 h 20

--- a/xspress3App/opi/edl/xspress3_4chan.edl
+++ b/xspress3App/opi/edl/xspress3_4chan.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 207
-y 68
+x 400
+y 250
 w 450
 h 525
 font "helvetica-medium-r-18.0"
@@ -326,9 +326,9 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 102
+x 120
 y 120
-w 100
+w 80
 h 20
 controlPv "$(P):det1:NumImages"
 format "decimal"
@@ -344,25 +344,6 @@ smartRefresh
 fastUpdate
 newPos
 objType "controls"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 5
-y 180
-w 150
-h 15
-font "helvetica-medium-r-12.0"
-fgColor rgb 0 0 0
-bgColor index 3
-useDisplayBg
-value {
-  "Dead Time Corr"
-}
 endObjectProperties
 
 # (Static Text)
@@ -587,31 +568,7 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 280
-y 175
-w 120
-h 15
-controlPv "$(P):det1:CTRL_DTC_RBV"
-format "decimal"
-font "helvetica-medium-r-12.0"
-fontAlign "left"
-fgColor rgb 2560 0 47104
-bgColor rgb 65280 65280 65280
-limitsFromDb
-nullColor rgb 60928 46592 11008
-smartRefresh
-fastUpdate
-newPos
-objType "controls"
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 7
-release 0
-x 285
+x 270
 y 210
 w 120
 h 15
@@ -654,9 +611,9 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 102
+x 120
 y 145
-w 100
+w 80
 h 20
 controlPv "$(P):det1:AcquireTime"
 format "decimal"
@@ -1055,6 +1012,25 @@ value {
 }
 endObjectProperties
 
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 5
+y 180
+w 110
+h 15
+font "helvetica-medium-r-12.0"
+fgColor rgb 0 0 0
+bgColor index 3
+useDisplayBg
+value {
+  "Erase on Start?"
+}
+endObjectProperties
+
 # (Message Button)
 object activeMessageButtonClass
 beginObjectProperties
@@ -1125,27 +1101,6 @@ onLabel "Stop"
 offLabel "Stop"
 3d
 font "helvetica-medium-r-14.0"
-endObjectProperties
-
-# (Choice Button)
-object activeChoiceButtonClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 155
-y 175
-w 120
-h 20
-fgColor rgb 0 0 0
-bgColor rgb 51200 51200 51200
-selectColor rgb 51200 51200 51200
-inconsistentColor rgb 0 0 0
-topShadowColor rgb 65280 65280 65280
-botShadowColor rgb 0 0 0
-controlPv "$(P):det1:CTRL_DTC"
-font "helvetica-medium-r-10.0"
-orientation "horizontal"
 endObjectProperties
 
 # (Message Button)
@@ -1242,7 +1197,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 155
+x 120
 y 210
 w 120
 h 20
@@ -1458,5 +1413,26 @@ replaceSymbols {
   0 1
   1 1
 }
+endObjectProperties
+
+# (Choice Button)
+object activeChoiceButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 120
+y 175
+w 120
+h 20
+fgColor rgb 0 0 0
+bgColor rgb 51200 51200 51200
+selectColor rgb 51200 51200 51200
+inconsistentColor rgb 0 0 0
+topShadowColor rgb 65280 65280 65280
+botShadowColor rgb 0 0 0
+controlPv "$(P):det1:EraseOnStart"
+font "helvetica-medium-r-10.0"
+orientation "horizontal"
 endObjectProperties
 

--- a/xspress3App/opi/edl/xspress3_7chan.edl
+++ b/xspress3App/opi/edl/xspress3_7chan.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 690
-y 186
+x 400
+y 250
 w 450
 h 525
 font "helvetica-medium-r-18.0"
@@ -326,9 +326,9 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 102
+x 120
 y 120
-w 100
+w 80
 h 20
 controlPv "$(P):det1:NumImages"
 format "decimal"
@@ -344,25 +344,6 @@ smartRefresh
 fastUpdate
 newPos
 objType "controls"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 5
-y 180
-w 150
-h 15
-font "helvetica-medium-r-12.0"
-fgColor rgb 0 0 0
-bgColor index 3
-useDisplayBg
-value {
-  "Dead Time Corr"
-}
 endObjectProperties
 
 # (Static Text)
@@ -587,31 +568,7 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 280
-y 175
-w 120
-h 15
-controlPv "$(P):det1:CTRL_DTC_RBV"
-format "decimal"
-font "helvetica-medium-r-12.0"
-fontAlign "left"
-fgColor rgb 2560 0 47104
-bgColor rgb 65280 65280 65280
-limitsFromDb
-nullColor rgb 60928 46592 11008
-smartRefresh
-fastUpdate
-newPos
-objType "controls"
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 7
-release 0
-x 285
+x 270
 y 210
 w 120
 h 15
@@ -654,9 +611,9 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 102
+x 120
 y 145
-w 100
+w 80
 h 20
 controlPv "$(P):det1:AcquireTime"
 format "decimal"
@@ -1055,6 +1012,25 @@ value {
 }
 endObjectProperties
 
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 5
+y 180
+w 110
+h 15
+font "helvetica-medium-r-12.0"
+fgColor rgb 0 0 0
+bgColor index 3
+useDisplayBg
+value {
+  "Erase on Start?"
+}
+endObjectProperties
+
 # (Message Button)
 object activeMessageButtonClass
 beginObjectProperties
@@ -1125,27 +1101,6 @@ onLabel "Stop"
 offLabel "Stop"
 3d
 font "helvetica-medium-r-14.0"
-endObjectProperties
-
-# (Choice Button)
-object activeChoiceButtonClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 155
-y 175
-w 120
-h 20
-fgColor rgb 0 0 0
-bgColor rgb 51200 51200 51200
-selectColor rgb 51200 51200 51200
-inconsistentColor rgb 0 0 0
-topShadowColor rgb 65280 65280 65280
-botShadowColor rgb 0 0 0
-controlPv "$(P):det1:CTRL_DTC"
-font "helvetica-medium-r-10.0"
-orientation "horizontal"
 endObjectProperties
 
 # (Message Button)
@@ -1242,7 +1197,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 155
+x 120
 y 210
 w 120
 h 20
@@ -1394,5 +1349,26 @@ replaceSymbols {
   2 1
   3 1
 }
+endObjectProperties
+
+# (Choice Button)
+object activeChoiceButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 120
+y 175
+w 120
+h 20
+fgColor rgb 0 0 0
+bgColor rgb 51200 51200 51200
+selectColor rgb 51200 51200 51200
+inconsistentColor rgb 0 0 0
+topShadowColor rgb 65280 65280 65280
+botShadowColor rgb 0 0 0
+controlPv "$(P):det1:EraseOnStart"
+font "helvetica-medium-r-10.0"
+orientation "horizontal"
 endObjectProperties
 

--- a/xspress3App/opi/edl/xspress3_8chan.edl
+++ b/xspress3App/opi/edl/xspress3_8chan.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 690
-y 186
+x 400
+y 250
 w 450
 h 525
 font "helvetica-medium-r-18.0"
@@ -326,9 +326,9 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 102
+x 120
 y 120
-w 100
+w 80
 h 20
 controlPv "$(P):det1:NumImages"
 format "decimal"
@@ -344,25 +344,6 @@ smartRefresh
 fastUpdate
 newPos
 objType "controls"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 5
-y 180
-w 150
-h 15
-font "helvetica-medium-r-12.0"
-fgColor rgb 0 0 0
-bgColor index 3
-useDisplayBg
-value {
-  "Dead Time Corr"
-}
 endObjectProperties
 
 # (Static Text)
@@ -587,31 +568,7 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 280
-y 175
-w 120
-h 15
-controlPv "$(P):det1:CTRL_DTC_RBV"
-format "decimal"
-font "helvetica-medium-r-12.0"
-fontAlign "left"
-fgColor rgb 2560 0 47104
-bgColor rgb 65280 65280 65280
-limitsFromDb
-nullColor rgb 60928 46592 11008
-smartRefresh
-fastUpdate
-newPos
-objType "controls"
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 7
-release 0
-x 285
+x 270
 y 210
 w 120
 h 15
@@ -654,9 +611,9 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 102
+x 120
 y 145
-w 100
+w 80
 h 20
 controlPv "$(P):det1:AcquireTime"
 format "decimal"
@@ -1055,6 +1012,25 @@ value {
 }
 endObjectProperties
 
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 5
+y 180
+w 110
+h 15
+font "helvetica-medium-r-12.0"
+fgColor rgb 0 0 0
+bgColor index 3
+useDisplayBg
+value {
+  "Erase on Start?"
+}
+endObjectProperties
+
 # (Message Button)
 object activeMessageButtonClass
 beginObjectProperties
@@ -1125,27 +1101,6 @@ onLabel "Stop"
 offLabel "Stop"
 3d
 font "helvetica-medium-r-14.0"
-endObjectProperties
-
-# (Choice Button)
-object activeChoiceButtonClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 155
-y 175
-w 120
-h 20
-fgColor rgb 0 0 0
-bgColor rgb 51200 51200 51200
-selectColor rgb 51200 51200 51200
-inconsistentColor rgb 0 0 0
-topShadowColor rgb 65280 65280 65280
-botShadowColor rgb 0 0 0
-controlPv "$(P):det1:CTRL_DTC"
-font "helvetica-medium-r-10.0"
-orientation "horizontal"
 endObjectProperties
 
 # (Message Button)
@@ -1246,7 +1201,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 155
+x 120
 y 210
 w 120
 h 20
@@ -1394,5 +1349,26 @@ replaceSymbols {
   0 1
   1 1
 }
+endObjectProperties
+
+# (Choice Button)
+object activeChoiceButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 120
+y 175
+w 120
+h 20
+fgColor rgb 0 0 0
+bgColor rgb 51200 51200 51200
+selectColor rgb 51200 51200 51200
+inconsistentColor rgb 0 0 0
+topShadowColor rgb 65280 65280 65280
+botShadowColor rgb 0 0 0
+controlPv "$(P):det1:EraseOnStart"
+font "helvetica-medium-r-10.0"
+orientation "horizontal"
 endObjectProperties
 

--- a/xspress3App/opi/opi/xspress3_14chan.opi
+++ b/xspress3App/opi/opi/xspress3_14chan.opi
@@ -28,8 +28,8 @@
   <snap_to_geometry>false</snap_to_geometry>
   <widget_type>Display</widget_type>
   <width>450</width>
-  <x>690</x>
-  <y>186</y>
+  <x>400</x>
+  <y>250</y>
   <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
     <actions hook="false" hook_all="false" />
     <alarm_pulsing>false</alarm_pulsing>
@@ -950,99 +950,9 @@ $(pv_value)</tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
-    <width>100</width>
-    <x>102</x>
+    <width>80</width>
+    <x>120</x>
     <y>120</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="200" green="200" blue="200" />
-    </background_color>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <opifont.name fontName="Sans" height="10" style="0" pixels="false">Default</opifont.name>
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal>true</horizontal>
-    <items>
-      <s>Choice 1</s>
-      <s>Choice 2</s>
-      <s>Choice 3</s>
-    </items>
-    <items_from_pv>true</items_from_pv>
-    <name>Choice Button</name>
-    <pv_name>$(P):det1:CTRL_DTC</pv_name>
-    <pv_value />
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <selected_color>
-      <color red="255" green="255" blue="255" />
-    </selected_color>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <visible>true</visible>
-    <widget_type>Choice Button</widget_type>
-    <width>120</width>
-    <x>155</x>
-    <y>175</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
-    </font>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>15</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Dead Time Corr</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>150</width>
-    <wrap_words>false</wrap_words>
-    <x>5</x>
-    <y>180</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -1791,57 +1701,6 @@ $(pv_value)</tooltip>
     <name>Text Update</name>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P):det1:CTRL_DTC_RBV</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>120</width>
-    <wrap_words>false</wrap_words>
-    <x>280</x>
-    <y>175</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>15</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
     <pv_name>$(P):det1:TriggerMode_RBV</pv_name>
     <pv_value />
     <rotation_angle>0.0</rotation_angle>
@@ -1862,7 +1721,7 @@ $(pv_value)</tooltip>
     <widget_type>Text Update</widget_type>
     <width>120</width>
     <wrap_words>false</wrap_words>
-    <x>285</x>
+    <x>270</x>
     <y>210</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
@@ -1906,7 +1765,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Menu Button</widget_type>
     <width>120</width>
-    <x>155</x>
+    <x>120</x>
     <y>210</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -2007,8 +1866,8 @@ $(pv_value)</tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
-    <width>100</width>
-    <x>102</x>
+    <width>80</width>
+    <x>120</x>
     <y>145</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -3151,5 +3010,95 @@ $(pv_value)</tooltip>
     <width>125</width>
     <x>320</x>
     <y>25</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>15</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Erase on Start?</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>110</width>
+    <wrap_words>false</wrap_words>
+    <x>5</x>
+    <y>180</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="200" green="200" blue="200" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Sans" height="10" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal>true</horizontal>
+    <items>
+      <s>Choice 1</s>
+      <s>Choice 2</s>
+      <s>Choice 3</s>
+    </items>
+    <items_from_pv>true</items_from_pv>
+    <name>Choice Button</name>
+    <pv_name>$(P):det1:EraseOnStart</pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <selected_color>
+      <color red="255" green="255" blue="255" />
+    </selected_color>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <visible>true</visible>
+    <widget_type>Choice Button</widget_type>
+    <width>120</width>
+    <x>120</x>
+    <y>175</y>
   </widget>
 </display>

--- a/xspress3App/opi/opi/xspress3_16chan.opi
+++ b/xspress3App/opi/opi/xspress3_16chan.opi
@@ -28,8 +28,8 @@
   <snap_to_geometry>false</snap_to_geometry>
   <widget_type>Display</widget_type>
   <width>450</width>
-  <x>690</x>
-  <y>186</y>
+  <x>400</x>
+  <y>250</y>
   <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
     <actions hook="false" hook_all="false" />
     <alarm_pulsing>false</alarm_pulsing>
@@ -950,99 +950,9 @@ $(pv_value)</tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
-    <width>100</width>
-    <x>102</x>
+    <width>80</width>
+    <x>120</x>
     <y>120</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="200" green="200" blue="200" />
-    </background_color>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <opifont.name fontName="Sans" height="10" style="0" pixels="false">Default</opifont.name>
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal>true</horizontal>
-    <items>
-      <s>Choice 1</s>
-      <s>Choice 2</s>
-      <s>Choice 3</s>
-    </items>
-    <items_from_pv>true</items_from_pv>
-    <name>Choice Button</name>
-    <pv_name>$(P):det1:CTRL_DTC</pv_name>
-    <pv_value />
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <selected_color>
-      <color red="255" green="255" blue="255" />
-    </selected_color>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <visible>true</visible>
-    <widget_type>Choice Button</widget_type>
-    <width>120</width>
-    <x>155</x>
-    <y>175</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
-    </font>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>15</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Dead Time Corr</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>150</width>
-    <wrap_words>false</wrap_words>
-    <x>5</x>
-    <y>180</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -1791,57 +1701,6 @@ $(pv_value)</tooltip>
     <name>Text Update</name>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P):det1:CTRL_DTC_RBV</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>120</width>
-    <wrap_words>false</wrap_words>
-    <x>280</x>
-    <y>175</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>15</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
     <pv_name>$(P):det1:TriggerMode_RBV</pv_name>
     <pv_value />
     <rotation_angle>0.0</rotation_angle>
@@ -1862,7 +1721,7 @@ $(pv_value)</tooltip>
     <widget_type>Text Update</widget_type>
     <width>120</width>
     <wrap_words>false</wrap_words>
-    <x>285</x>
+    <x>270</x>
     <y>210</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
@@ -1906,7 +1765,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Menu Button</widget_type>
     <width>120</width>
-    <x>155</x>
+    <x>120</x>
     <y>210</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -2007,8 +1866,8 @@ $(pv_value)</tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
-    <width>100</width>
-    <x>102</x>
+    <width>80</width>
+    <x>120</x>
     <y>145</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -3169,5 +3028,95 @@ $(pv_value)</tooltip>
     <width>125</width>
     <x>320</x>
     <y>30</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>15</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Erase on Start?</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>110</width>
+    <wrap_words>false</wrap_words>
+    <x>5</x>
+    <y>180</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="200" green="200" blue="200" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Sans" height="10" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal>true</horizontal>
+    <items>
+      <s>Choice 1</s>
+      <s>Choice 2</s>
+      <s>Choice 3</s>
+    </items>
+    <items_from_pv>true</items_from_pv>
+    <name>Choice Button</name>
+    <pv_name>$(P):det1:EraseOnStart</pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <selected_color>
+      <color red="255" green="255" blue="255" />
+    </selected_color>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <visible>true</visible>
+    <widget_type>Choice Button</widget_type>
+    <width>120</width>
+    <x>120</x>
+    <y>175</y>
   </widget>
 </display>

--- a/xspress3App/opi/opi/xspress3_1chan.opi
+++ b/xspress3App/opi/opi/xspress3_1chan.opi
@@ -28,8 +28,8 @@
   <snap_to_geometry>false</snap_to_geometry>
   <widget_type>Display</widget_type>
   <width>450</width>
-  <x>207</x>
-  <y>68</y>
+  <x>400</x>
+  <y>250</y>
   <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
     <actions hook="false" hook_all="false" />
     <alarm_pulsing>false</alarm_pulsing>
@@ -632,7 +632,7 @@ $(pv_value)</tooltip>
     <width>75</width>
     <wrap_words>false</wrap_words>
     <x>360</x>
-    <y>140</y>
+    <y>145</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -752,7 +752,7 @@ $(pv_value)</tooltip>
     <width>50</width>
     <wrap_words>false</wrap_words>
     <x>300</x>
-    <y>140</y>
+    <y>145</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -852,8 +852,8 @@ $(pv_value)</tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
-    <width>100</width>
-    <x>102</x>
+    <width>80</width>
+    <x>120</x>
     <y>120</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
@@ -886,7 +886,7 @@ $(pv_value)</tooltip>
     </items>
     <items_from_pv>true</items_from_pv>
     <name>Choice Button</name>
-    <pv_name>$(P):det1:CTRL_DTC</pv_name>
+    <pv_name>$(P):det1:EraseOnStart</pv_name>
     <pv_value />
     <rules />
     <scale_options>
@@ -903,7 +903,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Choice Button</widget_type>
     <width>120</width>
-    <x>155</x>
+    <x>120</x>
     <y>175</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -935,13 +935,13 @@ $(pv_value)</tooltip>
     </scale_options>
     <scripts />
     <show_scrollbar>false</show_scrollbar>
-    <text>Dead Time Corr</text>
+    <text>Erase on Start?</text>
     <tooltip></tooltip>
     <transparent>true</transparent>
     <vertical_alignment>1</vertical_alignment>
     <visible>true</visible>
     <widget_type>Label</widget_type>
-    <width>150</width>
+    <width>110</width>
     <wrap_words>false</wrap_words>
     <x>5</x>
     <y>180</y>
@@ -1685,57 +1685,6 @@ $(pv_value)</tooltip>
     <name>Text Update</name>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P):det1:CTRL_DTC_RBV</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>120</width>
-    <wrap_words>false</wrap_words>
-    <x>280</x>
-    <y>175</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>15</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
     <pv_name>$(P):det1:TriggerMode_RBV</pv_name>
     <pv_value />
     <rotation_angle>0.0</rotation_angle>
@@ -1756,7 +1705,7 @@ $(pv_value)</tooltip>
     <widget_type>Text Update</widget_type>
     <width>120</width>
     <wrap_words>false</wrap_words>
-    <x>285</x>
+    <x>270</x>
     <y>210</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
@@ -1800,7 +1749,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Menu Button</widget_type>
     <width>120</width>
-    <x>155</x>
+    <x>120</x>
     <y>210</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -1901,8 +1850,8 @@ $(pv_value)</tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
-    <width>100</width>
-    <x>102</x>
+    <width>80</width>
+    <x>120</x>
     <y>145</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">

--- a/xspress3App/opi/opi/xspress3_2chan.opi
+++ b/xspress3App/opi/opi/xspress3_2chan.opi
@@ -28,8 +28,8 @@
   <snap_to_geometry>false</snap_to_geometry>
   <widget_type>Display</widget_type>
   <width>450</width>
-  <x>207</x>
-  <y>68</y>
+  <x>400</x>
+  <y>250</y>
   <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
     <actions hook="false" hook_all="false" />
     <alarm_pulsing>false</alarm_pulsing>
@@ -632,7 +632,7 @@ $(pv_value)</tooltip>
     <width>75</width>
     <wrap_words>false</wrap_words>
     <x>360</x>
-    <y>140</y>
+    <y>145</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -752,7 +752,7 @@ $(pv_value)</tooltip>
     <width>50</width>
     <wrap_words>false</wrap_words>
     <x>300</x>
-    <y>140</y>
+    <y>145</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.bytemonitor" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -950,8 +950,8 @@ $(pv_value)</tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
-    <width>100</width>
-    <x>102</x>
+    <width>80</width>
+    <x>120</x>
     <y>120</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
@@ -984,7 +984,7 @@ $(pv_value)</tooltip>
     </items>
     <items_from_pv>true</items_from_pv>
     <name>Choice Button</name>
-    <pv_name>$(P):det1:CTRL_DTC</pv_name>
+    <pv_name>$(P):det1:EraseOnStart</pv_name>
     <pv_value />
     <rules />
     <scale_options>
@@ -1001,7 +1001,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Choice Button</widget_type>
     <width>120</width>
-    <x>155</x>
+    <x>120</x>
     <y>175</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -1033,13 +1033,13 @@ $(pv_value)</tooltip>
     </scale_options>
     <scripts />
     <show_scrollbar>false</show_scrollbar>
-    <text>Dead Time Corr</text>
+    <text>Erase on Start?</text>
     <tooltip></tooltip>
     <transparent>true</transparent>
     <vertical_alignment>1</vertical_alignment>
     <visible>true</visible>
     <widget_type>Label</widget_type>
-    <width>150</width>
+    <width>110</width>
     <wrap_words>false</wrap_words>
     <x>5</x>
     <y>180</y>
@@ -1783,57 +1783,6 @@ $(pv_value)</tooltip>
     <name>Text Update</name>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P):det1:CTRL_DTC_RBV</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>120</width>
-    <wrap_words>false</wrap_words>
-    <x>280</x>
-    <y>175</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>15</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
     <pv_name>$(P):det1:TriggerMode_RBV</pv_name>
     <pv_value />
     <rotation_angle>0.0</rotation_angle>
@@ -1854,7 +1803,7 @@ $(pv_value)</tooltip>
     <widget_type>Text Update</widget_type>
     <width>120</width>
     <wrap_words>false</wrap_words>
-    <x>285</x>
+    <x>270</x>
     <y>210</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
@@ -1898,7 +1847,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Menu Button</widget_type>
     <width>120</width>
-    <x>155</x>
+    <x>120</x>
     <y>210</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -1936,7 +1885,7 @@ $(pv_value)</tooltip>
     <vertical_alignment>1</vertical_alignment>
     <visible>true</visible>
     <widget_type>Label</widget_type>
-    <width>100</width>
+    <width>80</width>
     <wrap_words>false</wrap_words>
     <x>5</x>
     <y>150</y>
@@ -1999,8 +1948,8 @@ $(pv_value)</tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
-    <width>100</width>
-    <x>102</x>
+    <width>80</width>
+    <x>120</x>
     <y>145</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">

--- a/xspress3App/opi/opi/xspress3_4chan.opi
+++ b/xspress3App/opi/opi/xspress3_4chan.opi
@@ -28,8 +28,8 @@
   <snap_to_geometry>false</snap_to_geometry>
   <widget_type>Display</widget_type>
   <width>450</width>
-  <x>207</x>
-  <y>68</y>
+  <x>400</x>
+  <y>250</y>
   <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
     <actions hook="false" hook_all="false" />
     <alarm_pulsing>false</alarm_pulsing>
@@ -950,99 +950,9 @@ $(pv_value)</tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
-    <width>100</width>
-    <x>102</x>
+    <width>80</width>
+    <x>120</x>
     <y>120</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="200" green="200" blue="200" />
-    </background_color>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <opifont.name fontName="Sans" height="10" style="0" pixels="false">Default</opifont.name>
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal>true</horizontal>
-    <items>
-      <s>Choice 1</s>
-      <s>Choice 2</s>
-      <s>Choice 3</s>
-    </items>
-    <items_from_pv>true</items_from_pv>
-    <name>Choice Button</name>
-    <pv_name>$(P):det1:CTRL_DTC</pv_name>
-    <pv_value />
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <selected_color>
-      <color red="255" green="255" blue="255" />
-    </selected_color>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <visible>true</visible>
-    <widget_type>Choice Button</widget_type>
-    <width>120</width>
-    <x>155</x>
-    <y>175</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
-    </font>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>15</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Dead Time Corr</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>150</width>
-    <wrap_words>false</wrap_words>
-    <x>5</x>
-    <y>180</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -1783,57 +1693,6 @@ $(pv_value)</tooltip>
     <name>Text Update</name>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P):det1:CTRL_DTC_RBV</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>120</width>
-    <wrap_words>false</wrap_words>
-    <x>280</x>
-    <y>175</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>15</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
     <pv_name>$(P):det1:TriggerMode_RBV</pv_name>
     <pv_value />
     <rotation_angle>0.0</rotation_angle>
@@ -1854,7 +1713,7 @@ $(pv_value)</tooltip>
     <widget_type>Text Update</widget_type>
     <width>120</width>
     <wrap_words>false</wrap_words>
-    <x>285</x>
+    <x>270</x>
     <y>210</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
@@ -1898,7 +1757,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Menu Button</widget_type>
     <width>120</width>
-    <x>155</x>
+    <x>120</x>
     <y>210</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -1999,8 +1858,8 @@ $(pv_value)</tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
-    <width>100</width>
-    <x>102</x>
+    <width>80</width>
+    <x>120</x>
     <y>145</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -3192,5 +3051,95 @@ $(pv_value)</tooltip>
     <width>125</width>
     <x>320</x>
     <y>25</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>15</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Erase on Start?</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>110</width>
+    <wrap_words>false</wrap_words>
+    <x>5</x>
+    <y>180</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="200" green="200" blue="200" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Sans" height="10" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal>true</horizontal>
+    <items>
+      <s>Choice 1</s>
+      <s>Choice 2</s>
+      <s>Choice 3</s>
+    </items>
+    <items_from_pv>true</items_from_pv>
+    <name>Choice Button</name>
+    <pv_name>$(P):det1:EraseOnStart</pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <selected_color>
+      <color red="255" green="255" blue="255" />
+    </selected_color>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <visible>true</visible>
+    <widget_type>Choice Button</widget_type>
+    <width>120</width>
+    <x>120</x>
+    <y>175</y>
   </widget>
 </display>

--- a/xspress3App/opi/opi/xspress3_7chan.opi
+++ b/xspress3App/opi/opi/xspress3_7chan.opi
@@ -28,8 +28,8 @@
   <snap_to_geometry>false</snap_to_geometry>
   <widget_type>Display</widget_type>
   <width>450</width>
-  <x>690</x>
-  <y>186</y>
+  <x>400</x>
+  <y>250</y>
   <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
     <actions hook="false" hook_all="false" />
     <alarm_pulsing>false</alarm_pulsing>
@@ -950,99 +950,9 @@ $(pv_value)</tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
-    <width>100</width>
-    <x>102</x>
+    <width>80</width>
+    <x>120</x>
     <y>120</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="200" green="200" blue="200" />
-    </background_color>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <opifont.name fontName="Sans" height="10" style="0" pixels="false">Default</opifont.name>
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal>true</horizontal>
-    <items>
-      <s>Choice 1</s>
-      <s>Choice 2</s>
-      <s>Choice 3</s>
-    </items>
-    <items_from_pv>true</items_from_pv>
-    <name>Choice Button</name>
-    <pv_name>$(P):det1:CTRL_DTC</pv_name>
-    <pv_value />
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <selected_color>
-      <color red="255" green="255" blue="255" />
-    </selected_color>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <visible>true</visible>
-    <widget_type>Choice Button</widget_type>
-    <width>120</width>
-    <x>155</x>
-    <y>175</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
-    </font>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>15</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Dead Time Corr</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>150</width>
-    <wrap_words>false</wrap_words>
-    <x>5</x>
-    <y>180</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -1783,57 +1693,6 @@ $(pv_value)</tooltip>
     <name>Text Update</name>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P):det1:CTRL_DTC_RBV</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>120</width>
-    <wrap_words>false</wrap_words>
-    <x>280</x>
-    <y>175</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>15</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
     <pv_name>$(P):det1:TriggerMode_RBV</pv_name>
     <pv_value />
     <rotation_angle>0.0</rotation_angle>
@@ -1854,7 +1713,7 @@ $(pv_value)</tooltip>
     <widget_type>Text Update</widget_type>
     <width>120</width>
     <wrap_words>false</wrap_words>
-    <x>285</x>
+    <x>270</x>
     <y>210</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
@@ -1898,7 +1757,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Menu Button</widget_type>
     <width>120</width>
-    <x>155</x>
+    <x>120</x>
     <y>210</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -1999,8 +1858,8 @@ $(pv_value)</tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
-    <width>100</width>
-    <x>102</x>
+    <width>80</width>
+    <x>120</x>
     <y>145</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -3098,5 +2957,95 @@ $(pv_value)</tooltip>
     <width>125</width>
     <x>325</x>
     <y>25</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>15</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Erase on Start?</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>110</width>
+    <wrap_words>false</wrap_words>
+    <x>5</x>
+    <y>180</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="200" green="200" blue="200" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Sans" height="10" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal>true</horizontal>
+    <items>
+      <s>Choice 1</s>
+      <s>Choice 2</s>
+      <s>Choice 3</s>
+    </items>
+    <items_from_pv>true</items_from_pv>
+    <name>Choice Button</name>
+    <pv_name>$(P):det1:EraseOnStart</pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <selected_color>
+      <color red="255" green="255" blue="255" />
+    </selected_color>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <visible>true</visible>
+    <widget_type>Choice Button</widget_type>
+    <width>120</width>
+    <x>120</x>
+    <y>175</y>
   </widget>
 </display>

--- a/xspress3App/opi/opi/xspress3_8chan.opi
+++ b/xspress3App/opi/opi/xspress3_8chan.opi
@@ -28,8 +28,8 @@
   <snap_to_geometry>false</snap_to_geometry>
   <widget_type>Display</widget_type>
   <width>450</width>
-  <x>690</x>
-  <y>186</y>
+  <x>400</x>
+  <y>250</y>
   <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
     <actions hook="false" hook_all="false" />
     <alarm_pulsing>false</alarm_pulsing>
@@ -950,99 +950,9 @@ $(pv_value)</tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
-    <width>100</width>
-    <x>102</x>
+    <width>80</width>
+    <x>120</x>
     <y>120</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="200" green="200" blue="200" />
-    </background_color>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <opifont.name fontName="Sans" height="10" style="0" pixels="false">Default</opifont.name>
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal>true</horizontal>
-    <items>
-      <s>Choice 1</s>
-      <s>Choice 2</s>
-      <s>Choice 3</s>
-    </items>
-    <items_from_pv>true</items_from_pv>
-    <name>Choice Button</name>
-    <pv_name>$(P):det1:CTRL_DTC</pv_name>
-    <pv_value />
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <selected_color>
-      <color red="255" green="255" blue="255" />
-    </selected_color>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <visible>true</visible>
-    <widget_type>Choice Button</widget_type>
-    <width>120</width>
-    <x>155</x>
-    <y>175</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
-    </font>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>15</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Dead Time Corr</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>150</width>
-    <wrap_words>false</wrap_words>
-    <x>5</x>
-    <y>180</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -1791,57 +1701,6 @@ $(pv_value)</tooltip>
     <name>Text Update</name>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P):det1:CTRL_DTC_RBV</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>120</width>
-    <wrap_words>false</wrap_words>
-    <x>280</x>
-    <y>175</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>15</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
     <pv_name>$(P):det1:TriggerMode_RBV</pv_name>
     <pv_value />
     <rotation_angle>0.0</rotation_angle>
@@ -1862,7 +1721,7 @@ $(pv_value)</tooltip>
     <widget_type>Text Update</widget_type>
     <width>120</width>
     <wrap_words>false</wrap_words>
-    <x>285</x>
+    <x>270</x>
     <y>210</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
@@ -1906,7 +1765,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Menu Button</widget_type>
     <width>120</width>
-    <x>155</x>
+    <x>120</x>
     <y>210</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -2007,8 +1866,8 @@ $(pv_value)</tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
-    <width>100</width>
-    <x>102</x>
+    <width>80</width>
+    <x>120</x>
     <y>145</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -3097,5 +2956,95 @@ $(pv_value)</tooltip>
     <width>125</width>
     <x>325</x>
     <y>25</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="9" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>15</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Erase on Start?</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>110</width>
+    <wrap_words>false</wrap_words>
+    <x>5</x>
+    <y>180</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="200" green="200" blue="200" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Sans" height="10" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal>true</horizontal>
+    <items>
+      <s>Choice 1</s>
+      <s>Choice 2</s>
+      <s>Choice 3</s>
+    </items>
+    <items_from_pv>true</items_from_pv>
+    <name>Choice Button</name>
+    <pv_name>$(P):det1:EraseOnStart</pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <selected_color>
+      <color red="255" green="255" blue="255" />
+    </selected_color>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <visible>true</visible>
+    <widget_type>Choice Button</widget_type>
+    <width>120</width>
+    <x>120</x>
+    <y>175</y>
   </widget>
 </display>

--- a/xspress3App/opi/ui/xspress3_14chan.ui
+++ b/xspress3App/opi/ui/xspress3_14chan.ui
@@ -4,8 +4,8 @@
 <widget class="QMainWindow" name="MainWindow">
     <property name="geometry">
         <rect>
-            <x>690</x>
-            <y>186</y>
+            <x>400</x>
+            <y>250</y>
             <width>450</width>
             <height>525</height>
         </rect>
@@ -826,9 +826,9 @@ border-radius: 2px;
         <widget class="caTextEntry" name="caTextEntry_0">
             <property name="geometry">
                 <rect>
-                    <x>102</x>
+                    <x>120</x>
                     <y>120</y>
-                    <width>100</width>
+                    <width>80</width>
                     <height>20</height>
                 </rect>
             </property>
@@ -874,76 +874,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caChoice" name="caChoice_0">
-            <property name="geometry">
-                <rect>
-                    <x>155</x>
-                    <y>175</y>
-                    <width>120</width>
-                    <height>20</height>
-                </rect>
-            </property>
-            <property name="channel">
-                <string>$(P):det1:CTRL_DTC</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>200</red>
-                    <green>200</green>
-                    <blue>200</blue>
-                </color>
-            </property>
-            <property name="stackingMode">
-                <enum>Column</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caChoice::Static</enum>
-            </property>
-        </widget>
         <widget class="caLabel" name="caLabel_8">
-            <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="0">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="text">
-                <string>Dead Time Corr</string>
-            </property>
-            <property name="fontScaleMode">
-                <enum>ESimpleLabel::WidthAndHeight</enum>
-            </property>
-            <property name="geometry">
-                <rect>
-                    <x>5</x>
-                    <y>180</y>
-                    <width>150</width>
-                    <height>15</height>
-                </rect>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-        </widget>
-        <widget class="caLabel" name="caLabel_9">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1030,7 +961,7 @@ border-radius: 2px;
                 <enum>string</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_10">
+        <widget class="caLabel" name="caLabel_9">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1117,7 +1048,7 @@ border-radius: 2px;
                 <enum>string</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_11">
+        <widget class="caLabel" name="caLabel_10">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1507,61 +1438,7 @@ border-radius: 2px;
         <widget class="caLineEdit" name="caLineEdit_4">
             <property name="geometry">
                 <rect>
-                    <x>280</x>
-                    <y>175</y>
-                    <width>120</width>
-                    <height>15</height>
-                </rect>
-            </property>
-            <property name="fontScaleMode">
-                <enum>caLineEdit::WidthAndHeight</enum>
-            </property>
-            <property name="channel">
-                <string>$(P):det1:CTRL_DTC_RBV</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>10</red>
-                    <green>0</green>
-                    <blue>184</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>255</red>
-                    <green>255</green>
-                    <blue>255</blue>
-                </color>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="precisionMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="minValue">
-                <double>0.0</double>
-            </property>
-            <property name="maxValue">
-                <double>1.0</double>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-            <property name="formatType">
-                <enum>decimal</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caLineEdit::Static</enum>
-            </property>
-        </widget>
-        <widget class="caLineEdit" name="caLineEdit_5">
-            <property name="geometry">
-                <rect>
-                    <x>285</x>
+                    <x>270</x>
                     <y>210</y>
                     <width>120</width>
                     <height>15</height>
@@ -1615,7 +1492,7 @@ border-radius: 2px;
         <widget class="caMenu" name="caMenu_0">
             <property name="geometry">
                 <rect>
-                    <x>155</x>
+                    <x>120</x>
                     <y>210</y>
                     <width>120</width>
                     <height>20</height>
@@ -1642,7 +1519,7 @@ border-radius: 2px;
                 <enum>caMenu::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_12">
+        <widget class="caLabel" name="caLabel_11">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1681,9 +1558,9 @@ border-radius: 2px;
         <widget class="caTextEntry" name="caTextEntry_4">
             <property name="geometry">
                 <rect>
-                    <x>102</x>
+                    <x>120</x>
                     <y>145</y>
-                    <width>100</width>
+                    <width>80</width>
                     <height>20</height>
                 </rect>
             </property>
@@ -1729,7 +1606,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_6">
+        <widget class="caLineEdit" name="caLineEdit_5">
             <property name="geometry">
                 <rect>
                     <x>210</x>
@@ -1783,7 +1660,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_13">
+        <widget class="caLabel" name="caLabel_12">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1819,7 +1696,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_14">
+        <widget class="caLabel" name="caLabel_13">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1855,7 +1732,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_15">
+        <widget class="caLabel" name="caLabel_14">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1891,7 +1768,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_16">
+        <widget class="caLabel" name="caLabel_15">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1927,7 +1804,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_17">
+        <widget class="caLabel" name="caLabel_16">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1963,7 +1840,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_7">
+        <widget class="caLineEdit" name="caLineEdit_6">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2017,7 +1894,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_8">
+        <widget class="caLineEdit" name="caLineEdit_7">
             <property name="geometry">
                 <rect>
                     <x>170</x>
@@ -2071,7 +1948,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_18">
+        <widget class="caLabel" name="caLabel_17">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2107,7 +1984,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_9">
+        <widget class="caLineEdit" name="caLineEdit_8">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2161,7 +2038,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_19">
+        <widget class="caLabel" name="caLabel_18">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2227,7 +2104,7 @@ border-radius: 2px;
                 <enum>caMenu::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_20">
+        <widget class="caLabel" name="caLabel_19">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2314,7 +2191,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_21">
+        <widget class="caLabel" name="caLabel_20">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2350,7 +2227,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_10">
+        <widget class="caLineEdit" name="caLineEdit_9">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2404,7 +2281,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_22">
+        <widget class="caLabel" name="caLabel_21">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2491,7 +2368,7 @@ border-radius: 2px;
                 <enum>string</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_23">
+        <widget class="caLabel" name="caLabel_22">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2641,6 +2518,75 @@ border-radius: 2px;
                 <string>false;false</string>
             </property>
         </widget>
+        <widget class="caLabel" name="caLabel_23">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="text">
+                <string>Erase on Start?</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>5</x>
+                    <y>180</y>
+                    <width>110</width>
+                    <height>15</height>
+                </rect>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+        </widget>
+        <widget class="caChoice" name="caChoice_0">
+            <property name="geometry">
+                <rect>
+                    <x>120</x>
+                    <y>175</y>
+                    <width>120</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="channel">
+                <string>$(P):det1:EraseOnStart</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>200</red>
+                    <green>200</green>
+                    <blue>200</blue>
+                </color>
+            </property>
+            <property name="stackingMode">
+                <enum>Column</enum>
+            </property>
+            <property name="colorMode">
+                <enum>caChoice::Static</enum>
+            </property>
+        </widget>
         <zorder>caRectangle_0</zorder>
         <zorder>caLabel_0</zorder>
         <zorder>caLabel_1</zorder>
@@ -2676,7 +2622,6 @@ border-radius: 2px;
         <zorder>caLineEdit_2</zorder>
         <zorder>caByte_1</zorder>
         <zorder>caTextEntry_0</zorder>
-        <zorder>caChoice_0</zorder>
         <zorder>caTextEntry_1</zorder>
         <zorder>caTextEntry_2</zorder>
         <zorder>caTextEntry_3</zorder>
@@ -2688,20 +2633,20 @@ border-radius: 2px;
         <zorder>caRelatedDisplay_0</zorder>
         <zorder>caLineEdit_3</zorder>
         <zorder>caLineEdit_4</zorder>
-        <zorder>caLineEdit_5</zorder>
         <zorder>caMenu_0</zorder>
         <zorder>caTextEntry_4</zorder>
+        <zorder>caLineEdit_5</zorder>
         <zorder>caLineEdit_6</zorder>
         <zorder>caLineEdit_7</zorder>
         <zorder>caLineEdit_8</zorder>
-        <zorder>caLineEdit_9</zorder>
         <zorder>caMenu_1</zorder>
         <zorder>caTextEntry_5</zorder>
-        <zorder>caLineEdit_10</zorder>
+        <zorder>caLineEdit_9</zorder>
         <zorder>caTextEntry_6</zorder>
         <zorder>caMenu_2</zorder>
         <zorder>caRelatedDisplay_1</zorder>
         <zorder>caRelatedDisplay_2</zorder>
+        <zorder>caChoice_0</zorder>
     </widget>
 </widget>
 </ui>

--- a/xspress3App/opi/ui/xspress3_16chan.ui
+++ b/xspress3App/opi/ui/xspress3_16chan.ui
@@ -4,8 +4,8 @@
 <widget class="QMainWindow" name="MainWindow">
     <property name="geometry">
         <rect>
-            <x>690</x>
-            <y>186</y>
+            <x>400</x>
+            <y>250</y>
             <width>450</width>
             <height>525</height>
         </rect>
@@ -826,9 +826,9 @@ border-radius: 2px;
         <widget class="caTextEntry" name="caTextEntry_0">
             <property name="geometry">
                 <rect>
-                    <x>102</x>
+                    <x>120</x>
                     <y>120</y>
-                    <width>100</width>
+                    <width>80</width>
                     <height>20</height>
                 </rect>
             </property>
@@ -874,76 +874,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caChoice" name="caChoice_0">
-            <property name="geometry">
-                <rect>
-                    <x>155</x>
-                    <y>175</y>
-                    <width>120</width>
-                    <height>20</height>
-                </rect>
-            </property>
-            <property name="channel">
-                <string>$(P):det1:CTRL_DTC</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>200</red>
-                    <green>200</green>
-                    <blue>200</blue>
-                </color>
-            </property>
-            <property name="stackingMode">
-                <enum>Column</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caChoice::Static</enum>
-            </property>
-        </widget>
         <widget class="caLabel" name="caLabel_8">
-            <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="0">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="text">
-                <string>Dead Time Corr</string>
-            </property>
-            <property name="fontScaleMode">
-                <enum>ESimpleLabel::WidthAndHeight</enum>
-            </property>
-            <property name="geometry">
-                <rect>
-                    <x>5</x>
-                    <y>180</y>
-                    <width>150</width>
-                    <height>15</height>
-                </rect>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-        </widget>
-        <widget class="caLabel" name="caLabel_9">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1030,7 +961,7 @@ border-radius: 2px;
                 <enum>string</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_10">
+        <widget class="caLabel" name="caLabel_9">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1117,7 +1048,7 @@ border-radius: 2px;
                 <enum>string</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_11">
+        <widget class="caLabel" name="caLabel_10">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1507,61 +1438,7 @@ border-radius: 2px;
         <widget class="caLineEdit" name="caLineEdit_4">
             <property name="geometry">
                 <rect>
-                    <x>280</x>
-                    <y>175</y>
-                    <width>120</width>
-                    <height>15</height>
-                </rect>
-            </property>
-            <property name="fontScaleMode">
-                <enum>caLineEdit::WidthAndHeight</enum>
-            </property>
-            <property name="channel">
-                <string>$(P):det1:CTRL_DTC_RBV</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>10</red>
-                    <green>0</green>
-                    <blue>184</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>255</red>
-                    <green>255</green>
-                    <blue>255</blue>
-                </color>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="precisionMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="minValue">
-                <double>0.0</double>
-            </property>
-            <property name="maxValue">
-                <double>1.0</double>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-            <property name="formatType">
-                <enum>decimal</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caLineEdit::Static</enum>
-            </property>
-        </widget>
-        <widget class="caLineEdit" name="caLineEdit_5">
-            <property name="geometry">
-                <rect>
-                    <x>285</x>
+                    <x>270</x>
                     <y>210</y>
                     <width>120</width>
                     <height>15</height>
@@ -1615,7 +1492,7 @@ border-radius: 2px;
         <widget class="caMenu" name="caMenu_0">
             <property name="geometry">
                 <rect>
-                    <x>155</x>
+                    <x>120</x>
                     <y>210</y>
                     <width>120</width>
                     <height>20</height>
@@ -1642,7 +1519,7 @@ border-radius: 2px;
                 <enum>caMenu::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_12">
+        <widget class="caLabel" name="caLabel_11">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1681,9 +1558,9 @@ border-radius: 2px;
         <widget class="caTextEntry" name="caTextEntry_4">
             <property name="geometry">
                 <rect>
-                    <x>102</x>
+                    <x>120</x>
                     <y>145</y>
-                    <width>100</width>
+                    <width>80</width>
                     <height>20</height>
                 </rect>
             </property>
@@ -1729,7 +1606,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_6">
+        <widget class="caLineEdit" name="caLineEdit_5">
             <property name="geometry">
                 <rect>
                     <x>210</x>
@@ -1783,7 +1660,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_13">
+        <widget class="caLabel" name="caLabel_12">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1819,7 +1696,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_14">
+        <widget class="caLabel" name="caLabel_13">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1855,7 +1732,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_15">
+        <widget class="caLabel" name="caLabel_14">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1891,7 +1768,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_16">
+        <widget class="caLabel" name="caLabel_15">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1927,7 +1804,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_17">
+        <widget class="caLabel" name="caLabel_16">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1963,7 +1840,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_7">
+        <widget class="caLineEdit" name="caLineEdit_6">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2017,7 +1894,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_8">
+        <widget class="caLineEdit" name="caLineEdit_7">
             <property name="geometry">
                 <rect>
                     <x>170</x>
@@ -2071,7 +1948,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_18">
+        <widget class="caLabel" name="caLabel_17">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2107,7 +1984,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_9">
+        <widget class="caLineEdit" name="caLineEdit_8">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2161,7 +2038,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_19">
+        <widget class="caLabel" name="caLabel_18">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2227,7 +2104,7 @@ border-radius: 2px;
                 <enum>caMenu::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_20">
+        <widget class="caLabel" name="caLabel_19">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2314,7 +2191,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_21">
+        <widget class="caLabel" name="caLabel_20">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2350,7 +2227,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_10">
+        <widget class="caLineEdit" name="caLineEdit_9">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2404,7 +2281,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_22">
+        <widget class="caLabel" name="caLabel_21">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2491,7 +2368,7 @@ border-radius: 2px;
                 <enum>string</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_23">
+        <widget class="caLabel" name="caLabel_22">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2641,6 +2518,75 @@ border-radius: 2px;
                 <string>false;false</string>
             </property>
         </widget>
+        <widget class="caLabel" name="caLabel_23">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="text">
+                <string>Erase on Start?</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>5</x>
+                    <y>180</y>
+                    <width>110</width>
+                    <height>15</height>
+                </rect>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+        </widget>
+        <widget class="caChoice" name="caChoice_0">
+            <property name="geometry">
+                <rect>
+                    <x>120</x>
+                    <y>175</y>
+                    <width>120</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="channel">
+                <string>$(P):det1:EraseOnStart</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>200</red>
+                    <green>200</green>
+                    <blue>200</blue>
+                </color>
+            </property>
+            <property name="stackingMode">
+                <enum>Column</enum>
+            </property>
+            <property name="colorMode">
+                <enum>caChoice::Static</enum>
+            </property>
+        </widget>
         <zorder>caRectangle_0</zorder>
         <zorder>caLabel_0</zorder>
         <zorder>caLabel_1</zorder>
@@ -2676,7 +2622,6 @@ border-radius: 2px;
         <zorder>caLineEdit_2</zorder>
         <zorder>caByte_1</zorder>
         <zorder>caTextEntry_0</zorder>
-        <zorder>caChoice_0</zorder>
         <zorder>caTextEntry_1</zorder>
         <zorder>caTextEntry_2</zorder>
         <zorder>caTextEntry_3</zorder>
@@ -2688,20 +2633,20 @@ border-radius: 2px;
         <zorder>caRelatedDisplay_0</zorder>
         <zorder>caLineEdit_3</zorder>
         <zorder>caLineEdit_4</zorder>
-        <zorder>caLineEdit_5</zorder>
         <zorder>caMenu_0</zorder>
         <zorder>caTextEntry_4</zorder>
+        <zorder>caLineEdit_5</zorder>
         <zorder>caLineEdit_6</zorder>
         <zorder>caLineEdit_7</zorder>
         <zorder>caLineEdit_8</zorder>
-        <zorder>caLineEdit_9</zorder>
         <zorder>caMenu_1</zorder>
         <zorder>caTextEntry_5</zorder>
-        <zorder>caLineEdit_10</zorder>
+        <zorder>caLineEdit_9</zorder>
         <zorder>caTextEntry_6</zorder>
         <zorder>caMenu_2</zorder>
         <zorder>caRelatedDisplay_1</zorder>
         <zorder>caRelatedDisplay_2</zorder>
+        <zorder>caChoice_0</zorder>
     </widget>
 </widget>
 </ui>

--- a/xspress3App/opi/ui/xspress3_1chan.ui
+++ b/xspress3App/opi/ui/xspress3_1chan.ui
@@ -4,8 +4,8 @@
 <widget class="QMainWindow" name="MainWindow">
     <property name="geometry">
         <rect>
-            <x>207</x>
-            <y>68</y>
+            <x>400</x>
+            <y>250</y>
             <width>450</width>
             <height>525</height>
         </rect>
@@ -551,7 +551,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>360</x>
-                    <y>140</y>
+                    <y>145</y>
                     <width>75</width>
                     <height>15</height>
                 </rect>
@@ -700,7 +700,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>300</x>
-                    <y>140</y>
+                    <y>145</y>
                     <width>50</width>
                     <height>15</height>
                 </rect>
@@ -748,9 +748,9 @@ border-radius: 2px;
         <widget class="caTextEntry" name="caTextEntry_0">
             <property name="geometry">
                 <rect>
-                    <x>102</x>
+                    <x>120</x>
                     <y>120</y>
-                    <width>100</width>
+                    <width>80</width>
                     <height>20</height>
                 </rect>
             </property>
@@ -799,14 +799,14 @@ border-radius: 2px;
         <widget class="caChoice" name="caChoice_0">
             <property name="geometry">
                 <rect>
-                    <x>155</x>
+                    <x>120</x>
                     <y>175</y>
                     <width>120</width>
                     <height>20</height>
                 </rect>
             </property>
             <property name="channel">
-                <string>$(P):det1:CTRL_DTC</string>
+                <string>$(P):det1:EraseOnStart</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -848,7 +848,7 @@ border-radius: 2px;
                 </color>
             </property>
             <property name="text">
-                <string>Dead Time Corr</string>
+                <string>Erase on Start?</string>
             </property>
             <property name="fontScaleMode">
                 <enum>ESimpleLabel::WidthAndHeight</enum>
@@ -857,7 +857,7 @@ border-radius: 2px;
                 <rect>
                     <x>5</x>
                     <y>180</y>
-                    <width>150</width>
+                    <width>110</width>
                     <height>15</height>
                 </rect>
             </property>
@@ -1429,61 +1429,7 @@ border-radius: 2px;
         <widget class="caLineEdit" name="caLineEdit_4">
             <property name="geometry">
                 <rect>
-                    <x>280</x>
-                    <y>175</y>
-                    <width>120</width>
-                    <height>15</height>
-                </rect>
-            </property>
-            <property name="fontScaleMode">
-                <enum>caLineEdit::WidthAndHeight</enum>
-            </property>
-            <property name="channel">
-                <string>$(P):det1:CTRL_DTC_RBV</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>10</red>
-                    <green>0</green>
-                    <blue>184</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>255</red>
-                    <green>255</green>
-                    <blue>255</blue>
-                </color>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="precisionMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="minValue">
-                <double>0.0</double>
-            </property>
-            <property name="maxValue">
-                <double>1.0</double>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-            <property name="formatType">
-                <enum>decimal</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caLineEdit::Static</enum>
-            </property>
-        </widget>
-        <widget class="caLineEdit" name="caLineEdit_5">
-            <property name="geometry">
-                <rect>
-                    <x>285</x>
+                    <x>270</x>
                     <y>210</y>
                     <width>120</width>
                     <height>15</height>
@@ -1537,7 +1483,7 @@ border-radius: 2px;
         <widget class="caMenu" name="caMenu_0">
             <property name="geometry">
                 <rect>
-                    <x>155</x>
+                    <x>120</x>
                     <y>210</y>
                     <width>120</width>
                     <height>20</height>
@@ -1603,9 +1549,9 @@ border-radius: 2px;
         <widget class="caTextEntry" name="caTextEntry_4">
             <property name="geometry">
                 <rect>
-                    <x>102</x>
+                    <x>120</x>
                     <y>145</y>
-                    <width>100</width>
+                    <width>80</width>
                     <height>20</height>
                 </rect>
             </property>
@@ -1651,7 +1597,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_6">
+        <widget class="caLineEdit" name="caLineEdit_5">
             <property name="geometry">
                 <rect>
                     <x>210</x>
@@ -1885,7 +1831,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_7">
+        <widget class="caLineEdit" name="caLineEdit_6">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -1939,7 +1885,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_8">
+        <widget class="caLineEdit" name="caLineEdit_7">
             <property name="geometry">
                 <rect>
                     <x>170</x>
@@ -2029,7 +1975,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_9">
+        <widget class="caLineEdit" name="caLineEdit_8">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2272,7 +2218,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_10">
+        <widget class="caLineEdit" name="caLineEdit_9">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2645,16 +2591,15 @@ border-radius: 2px;
         <zorder>caRelatedDisplay_0</zorder>
         <zorder>caLineEdit_3</zorder>
         <zorder>caLineEdit_4</zorder>
-        <zorder>caLineEdit_5</zorder>
         <zorder>caMenu_0</zorder>
         <zorder>caTextEntry_4</zorder>
+        <zorder>caLineEdit_5</zorder>
         <zorder>caLineEdit_6</zorder>
         <zorder>caLineEdit_7</zorder>
         <zorder>caLineEdit_8</zorder>
-        <zorder>caLineEdit_9</zorder>
         <zorder>caMenu_1</zorder>
         <zorder>caTextEntry_5</zorder>
-        <zorder>caLineEdit_10</zorder>
+        <zorder>caLineEdit_9</zorder>
         <zorder>caTextEntry_6</zorder>
         <zorder>caMenu_2</zorder>
         <zorder>caRelatedDisplay_1</zorder>

--- a/xspress3App/opi/ui/xspress3_2chan.ui
+++ b/xspress3App/opi/ui/xspress3_2chan.ui
@@ -4,8 +4,8 @@
 <widget class="QMainWindow" name="MainWindow">
     <property name="geometry">
         <rect>
-            <x>207</x>
-            <y>68</y>
+            <x>400</x>
+            <y>250</y>
             <width>450</width>
             <height>525</height>
         </rect>
@@ -551,7 +551,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>360</x>
-                    <y>140</y>
+                    <y>145</y>
                     <width>75</width>
                     <height>15</height>
                 </rect>
@@ -700,7 +700,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>300</x>
-                    <y>140</y>
+                    <y>145</y>
                     <width>50</width>
                     <height>15</height>
                 </rect>
@@ -826,9 +826,9 @@ border-radius: 2px;
         <widget class="caTextEntry" name="caTextEntry_0">
             <property name="geometry">
                 <rect>
-                    <x>102</x>
+                    <x>120</x>
                     <y>120</y>
-                    <width>100</width>
+                    <width>80</width>
                     <height>20</height>
                 </rect>
             </property>
@@ -877,14 +877,14 @@ border-radius: 2px;
         <widget class="caChoice" name="caChoice_0">
             <property name="geometry">
                 <rect>
-                    <x>155</x>
+                    <x>120</x>
                     <y>175</y>
                     <width>120</width>
                     <height>20</height>
                 </rect>
             </property>
             <property name="channel">
-                <string>$(P):det1:CTRL_DTC</string>
+                <string>$(P):det1:EraseOnStart</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -926,7 +926,7 @@ border-radius: 2px;
                 </color>
             </property>
             <property name="text">
-                <string>Dead Time Corr</string>
+                <string>Erase on Start?</string>
             </property>
             <property name="fontScaleMode">
                 <enum>ESimpleLabel::WidthAndHeight</enum>
@@ -935,7 +935,7 @@ border-radius: 2px;
                 <rect>
                     <x>5</x>
                     <y>180</y>
-                    <width>150</width>
+                    <width>110</width>
                     <height>15</height>
                 </rect>
             </property>
@@ -1507,61 +1507,7 @@ border-radius: 2px;
         <widget class="caLineEdit" name="caLineEdit_4">
             <property name="geometry">
                 <rect>
-                    <x>280</x>
-                    <y>175</y>
-                    <width>120</width>
-                    <height>15</height>
-                </rect>
-            </property>
-            <property name="fontScaleMode">
-                <enum>caLineEdit::WidthAndHeight</enum>
-            </property>
-            <property name="channel">
-                <string>$(P):det1:CTRL_DTC_RBV</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>10</red>
-                    <green>0</green>
-                    <blue>184</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>255</red>
-                    <green>255</green>
-                    <blue>255</blue>
-                </color>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="precisionMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="minValue">
-                <double>0.0</double>
-            </property>
-            <property name="maxValue">
-                <double>1.0</double>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-            <property name="formatType">
-                <enum>decimal</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caLineEdit::Static</enum>
-            </property>
-        </widget>
-        <widget class="caLineEdit" name="caLineEdit_5">
-            <property name="geometry">
-                <rect>
-                    <x>285</x>
+                    <x>270</x>
                     <y>210</y>
                     <width>120</width>
                     <height>15</height>
@@ -1615,7 +1561,7 @@ border-radius: 2px;
         <widget class="caMenu" name="caMenu_0">
             <property name="geometry">
                 <rect>
-                    <x>155</x>
+                    <x>120</x>
                     <y>210</y>
                     <width>120</width>
                     <height>20</height>
@@ -1670,7 +1616,7 @@ border-radius: 2px;
                 <rect>
                     <x>5</x>
                     <y>150</y>
-                    <width>100</width>
+                    <width>80</width>
                     <height>15</height>
                 </rect>
             </property>
@@ -1681,9 +1627,9 @@ border-radius: 2px;
         <widget class="caTextEntry" name="caTextEntry_4">
             <property name="geometry">
                 <rect>
-                    <x>102</x>
+                    <x>120</x>
                     <y>145</y>
-                    <width>100</width>
+                    <width>80</width>
                     <height>20</height>
                 </rect>
             </property>
@@ -1729,7 +1675,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_6">
+        <widget class="caLineEdit" name="caLineEdit_5">
             <property name="geometry">
                 <rect>
                     <x>210</x>
@@ -1963,7 +1909,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_7">
+        <widget class="caLineEdit" name="caLineEdit_6">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2017,7 +1963,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_8">
+        <widget class="caLineEdit" name="caLineEdit_7">
             <property name="geometry">
                 <rect>
                     <x>170</x>
@@ -2107,7 +2053,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_9">
+        <widget class="caLineEdit" name="caLineEdit_8">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2350,7 +2296,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_10">
+        <widget class="caLineEdit" name="caLineEdit_9">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2688,16 +2634,15 @@ border-radius: 2px;
         <zorder>caRelatedDisplay_0</zorder>
         <zorder>caLineEdit_3</zorder>
         <zorder>caLineEdit_4</zorder>
-        <zorder>caLineEdit_5</zorder>
         <zorder>caMenu_0</zorder>
         <zorder>caTextEntry_4</zorder>
+        <zorder>caLineEdit_5</zorder>
         <zorder>caLineEdit_6</zorder>
         <zorder>caLineEdit_7</zorder>
         <zorder>caLineEdit_8</zorder>
-        <zorder>caLineEdit_9</zorder>
         <zorder>caMenu_1</zorder>
         <zorder>caTextEntry_5</zorder>
-        <zorder>caLineEdit_10</zorder>
+        <zorder>caLineEdit_9</zorder>
         <zorder>caTextEntry_6</zorder>
         <zorder>caMenu_2</zorder>
         <zorder>caRelatedDisplay_1</zorder>

--- a/xspress3App/opi/ui/xspress3_4chan.ui
+++ b/xspress3App/opi/ui/xspress3_4chan.ui
@@ -4,8 +4,8 @@
 <widget class="QMainWindow" name="MainWindow">
     <property name="geometry">
         <rect>
-            <x>207</x>
-            <y>68</y>
+            <x>400</x>
+            <y>250</y>
             <width>450</width>
             <height>525</height>
         </rect>
@@ -826,9 +826,9 @@ border-radius: 2px;
         <widget class="caTextEntry" name="caTextEntry_0">
             <property name="geometry">
                 <rect>
-                    <x>102</x>
+                    <x>120</x>
                     <y>120</y>
-                    <width>100</width>
+                    <width>80</width>
                     <height>20</height>
                 </rect>
             </property>
@@ -874,76 +874,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caChoice" name="caChoice_0">
-            <property name="geometry">
-                <rect>
-                    <x>155</x>
-                    <y>175</y>
-                    <width>120</width>
-                    <height>20</height>
-                </rect>
-            </property>
-            <property name="channel">
-                <string>$(P):det1:CTRL_DTC</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>200</red>
-                    <green>200</green>
-                    <blue>200</blue>
-                </color>
-            </property>
-            <property name="stackingMode">
-                <enum>Column</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caChoice::Static</enum>
-            </property>
-        </widget>
         <widget class="caLabel" name="caLabel_8">
-            <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="0">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="text">
-                <string>Dead Time Corr</string>
-            </property>
-            <property name="fontScaleMode">
-                <enum>ESimpleLabel::WidthAndHeight</enum>
-            </property>
-            <property name="geometry">
-                <rect>
-                    <x>5</x>
-                    <y>180</y>
-                    <width>150</width>
-                    <height>15</height>
-                </rect>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-        </widget>
-        <widget class="caLabel" name="caLabel_9">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1030,7 +961,7 @@ border-radius: 2px;
                 <enum>string</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_10">
+        <widget class="caLabel" name="caLabel_9">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1117,7 +1048,7 @@ border-radius: 2px;
                 <enum>string</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_11">
+        <widget class="caLabel" name="caLabel_10">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1507,61 +1438,7 @@ border-radius: 2px;
         <widget class="caLineEdit" name="caLineEdit_4">
             <property name="geometry">
                 <rect>
-                    <x>280</x>
-                    <y>175</y>
-                    <width>120</width>
-                    <height>15</height>
-                </rect>
-            </property>
-            <property name="fontScaleMode">
-                <enum>caLineEdit::WidthAndHeight</enum>
-            </property>
-            <property name="channel">
-                <string>$(P):det1:CTRL_DTC_RBV</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>10</red>
-                    <green>0</green>
-                    <blue>184</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>255</red>
-                    <green>255</green>
-                    <blue>255</blue>
-                </color>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="precisionMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="minValue">
-                <double>0.0</double>
-            </property>
-            <property name="maxValue">
-                <double>1.0</double>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-            <property name="formatType">
-                <enum>decimal</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caLineEdit::Static</enum>
-            </property>
-        </widget>
-        <widget class="caLineEdit" name="caLineEdit_5">
-            <property name="geometry">
-                <rect>
-                    <x>285</x>
+                    <x>270</x>
                     <y>210</y>
                     <width>120</width>
                     <height>15</height>
@@ -1615,7 +1492,7 @@ border-radius: 2px;
         <widget class="caMenu" name="caMenu_0">
             <property name="geometry">
                 <rect>
-                    <x>155</x>
+                    <x>120</x>
                     <y>210</y>
                     <width>120</width>
                     <height>20</height>
@@ -1642,7 +1519,7 @@ border-radius: 2px;
                 <enum>caMenu::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_12">
+        <widget class="caLabel" name="caLabel_11">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1681,9 +1558,9 @@ border-radius: 2px;
         <widget class="caTextEntry" name="caTextEntry_4">
             <property name="geometry">
                 <rect>
-                    <x>102</x>
+                    <x>120</x>
                     <y>145</y>
-                    <width>100</width>
+                    <width>80</width>
                     <height>20</height>
                 </rect>
             </property>
@@ -1729,7 +1606,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_6">
+        <widget class="caLineEdit" name="caLineEdit_5">
             <property name="geometry">
                 <rect>
                     <x>210</x>
@@ -1783,7 +1660,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_13">
+        <widget class="caLabel" name="caLabel_12">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1819,7 +1696,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_14">
+        <widget class="caLabel" name="caLabel_13">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1855,7 +1732,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_15">
+        <widget class="caLabel" name="caLabel_14">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1891,7 +1768,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_16">
+        <widget class="caLabel" name="caLabel_15">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1927,7 +1804,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_17">
+        <widget class="caLabel" name="caLabel_16">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1963,7 +1840,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_7">
+        <widget class="caLineEdit" name="caLineEdit_6">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2017,7 +1894,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_8">
+        <widget class="caLineEdit" name="caLineEdit_7">
             <property name="geometry">
                 <rect>
                     <x>170</x>
@@ -2071,7 +1948,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_18">
+        <widget class="caLabel" name="caLabel_17">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2107,7 +1984,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_9">
+        <widget class="caLineEdit" name="caLineEdit_8">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2161,7 +2038,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_19">
+        <widget class="caLabel" name="caLabel_18">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2227,7 +2104,7 @@ border-radius: 2px;
                 <enum>caMenu::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_20">
+        <widget class="caLabel" name="caLabel_19">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2314,7 +2191,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_21">
+        <widget class="caLabel" name="caLabel_20">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2350,7 +2227,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_10">
+        <widget class="caLineEdit" name="caLineEdit_9">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2404,7 +2281,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_22">
+        <widget class="caLabel" name="caLabel_21">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2491,7 +2368,7 @@ border-radius: 2px;
                 <enum>string</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_23">
+        <widget class="caLabel" name="caLabel_22">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2767,6 +2644,75 @@ border-radius: 2px;
                 <string>false;false</string>
             </property>
         </widget>
+        <widget class="caLabel" name="caLabel_23">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="text">
+                <string>Erase on Start?</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>5</x>
+                    <y>180</y>
+                    <width>110</width>
+                    <height>15</height>
+                </rect>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+        </widget>
+        <widget class="caChoice" name="caChoice_0">
+            <property name="geometry">
+                <rect>
+                    <x>120</x>
+                    <y>175</y>
+                    <width>120</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="channel">
+                <string>$(P):det1:EraseOnStart</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>200</red>
+                    <green>200</green>
+                    <blue>200</blue>
+                </color>
+            </property>
+            <property name="stackingMode">
+                <enum>Column</enum>
+            </property>
+            <property name="colorMode">
+                <enum>caChoice::Static</enum>
+            </property>
+        </widget>
         <zorder>caRectangle_0</zorder>
         <zorder>caLabel_0</zorder>
         <zorder>caLabel_1</zorder>
@@ -2802,7 +2748,6 @@ border-radius: 2px;
         <zorder>caLineEdit_2</zorder>
         <zorder>caByte_1</zorder>
         <zorder>caTextEntry_0</zorder>
-        <zorder>caChoice_0</zorder>
         <zorder>caTextEntry_1</zorder>
         <zorder>caTextEntry_2</zorder>
         <zorder>caTextEntry_3</zorder>
@@ -2814,16 +2759,15 @@ border-radius: 2px;
         <zorder>caRelatedDisplay_0</zorder>
         <zorder>caLineEdit_3</zorder>
         <zorder>caLineEdit_4</zorder>
-        <zorder>caLineEdit_5</zorder>
         <zorder>caMenu_0</zorder>
         <zorder>caTextEntry_4</zorder>
+        <zorder>caLineEdit_5</zorder>
         <zorder>caLineEdit_6</zorder>
         <zorder>caLineEdit_7</zorder>
         <zorder>caLineEdit_8</zorder>
-        <zorder>caLineEdit_9</zorder>
         <zorder>caMenu_1</zorder>
         <zorder>caTextEntry_5</zorder>
-        <zorder>caLineEdit_10</zorder>
+        <zorder>caLineEdit_9</zorder>
         <zorder>caTextEntry_6</zorder>
         <zorder>caMenu_2</zorder>
         <zorder>caRelatedDisplay_1</zorder>
@@ -2831,6 +2775,7 @@ border-radius: 2px;
         <zorder>caRelatedDisplay_3</zorder>
         <zorder>caRelatedDisplay_4</zorder>
         <zorder>caRelatedDisplay_5</zorder>
+        <zorder>caChoice_0</zorder>
     </widget>
 </widget>
 </ui>

--- a/xspress3App/opi/ui/xspress3_7chan.ui
+++ b/xspress3App/opi/ui/xspress3_7chan.ui
@@ -4,8 +4,8 @@
 <widget class="QMainWindow" name="MainWindow">
     <property name="geometry">
         <rect>
-            <x>690</x>
-            <y>186</y>
+            <x>400</x>
+            <y>250</y>
             <width>450</width>
             <height>525</height>
         </rect>
@@ -826,9 +826,9 @@ border-radius: 2px;
         <widget class="caTextEntry" name="caTextEntry_0">
             <property name="geometry">
                 <rect>
-                    <x>102</x>
+                    <x>120</x>
                     <y>120</y>
-                    <width>100</width>
+                    <width>80</width>
                     <height>20</height>
                 </rect>
             </property>
@@ -874,76 +874,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caChoice" name="caChoice_0">
-            <property name="geometry">
-                <rect>
-                    <x>155</x>
-                    <y>175</y>
-                    <width>120</width>
-                    <height>20</height>
-                </rect>
-            </property>
-            <property name="channel">
-                <string>$(P):det1:CTRL_DTC</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>200</red>
-                    <green>200</green>
-                    <blue>200</blue>
-                </color>
-            </property>
-            <property name="stackingMode">
-                <enum>Column</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caChoice::Static</enum>
-            </property>
-        </widget>
         <widget class="caLabel" name="caLabel_8">
-            <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="0">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="text">
-                <string>Dead Time Corr</string>
-            </property>
-            <property name="fontScaleMode">
-                <enum>ESimpleLabel::WidthAndHeight</enum>
-            </property>
-            <property name="geometry">
-                <rect>
-                    <x>5</x>
-                    <y>180</y>
-                    <width>150</width>
-                    <height>15</height>
-                </rect>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-        </widget>
-        <widget class="caLabel" name="caLabel_9">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1030,7 +961,7 @@ border-radius: 2px;
                 <enum>string</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_10">
+        <widget class="caLabel" name="caLabel_9">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1117,7 +1048,7 @@ border-radius: 2px;
                 <enum>string</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_11">
+        <widget class="caLabel" name="caLabel_10">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1507,61 +1438,7 @@ border-radius: 2px;
         <widget class="caLineEdit" name="caLineEdit_4">
             <property name="geometry">
                 <rect>
-                    <x>280</x>
-                    <y>175</y>
-                    <width>120</width>
-                    <height>15</height>
-                </rect>
-            </property>
-            <property name="fontScaleMode">
-                <enum>caLineEdit::WidthAndHeight</enum>
-            </property>
-            <property name="channel">
-                <string>$(P):det1:CTRL_DTC_RBV</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>10</red>
-                    <green>0</green>
-                    <blue>184</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>255</red>
-                    <green>255</green>
-                    <blue>255</blue>
-                </color>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="precisionMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="minValue">
-                <double>0.0</double>
-            </property>
-            <property name="maxValue">
-                <double>1.0</double>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-            <property name="formatType">
-                <enum>decimal</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caLineEdit::Static</enum>
-            </property>
-        </widget>
-        <widget class="caLineEdit" name="caLineEdit_5">
-            <property name="geometry">
-                <rect>
-                    <x>285</x>
+                    <x>270</x>
                     <y>210</y>
                     <width>120</width>
                     <height>15</height>
@@ -1615,7 +1492,7 @@ border-radius: 2px;
         <widget class="caMenu" name="caMenu_0">
             <property name="geometry">
                 <rect>
-                    <x>155</x>
+                    <x>120</x>
                     <y>210</y>
                     <width>120</width>
                     <height>20</height>
@@ -1642,7 +1519,7 @@ border-radius: 2px;
                 <enum>caMenu::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_12">
+        <widget class="caLabel" name="caLabel_11">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1681,9 +1558,9 @@ border-radius: 2px;
         <widget class="caTextEntry" name="caTextEntry_4">
             <property name="geometry">
                 <rect>
-                    <x>102</x>
+                    <x>120</x>
                     <y>145</y>
-                    <width>100</width>
+                    <width>80</width>
                     <height>20</height>
                 </rect>
             </property>
@@ -1729,7 +1606,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_6">
+        <widget class="caLineEdit" name="caLineEdit_5">
             <property name="geometry">
                 <rect>
                     <x>210</x>
@@ -1783,7 +1660,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_13">
+        <widget class="caLabel" name="caLabel_12">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1819,7 +1696,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_14">
+        <widget class="caLabel" name="caLabel_13">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1855,7 +1732,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_15">
+        <widget class="caLabel" name="caLabel_14">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1891,7 +1768,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_16">
+        <widget class="caLabel" name="caLabel_15">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1927,7 +1804,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_17">
+        <widget class="caLabel" name="caLabel_16">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1963,7 +1840,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_7">
+        <widget class="caLineEdit" name="caLineEdit_6">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2017,7 +1894,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_8">
+        <widget class="caLineEdit" name="caLineEdit_7">
             <property name="geometry">
                 <rect>
                     <x>170</x>
@@ -2071,7 +1948,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_18">
+        <widget class="caLabel" name="caLabel_17">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2107,7 +1984,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_9">
+        <widget class="caLineEdit" name="caLineEdit_8">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2161,7 +2038,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_19">
+        <widget class="caLabel" name="caLabel_18">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2227,7 +2104,7 @@ border-radius: 2px;
                 <enum>caMenu::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_20">
+        <widget class="caLabel" name="caLabel_19">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2314,7 +2191,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_21">
+        <widget class="caLabel" name="caLabel_20">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2350,7 +2227,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_10">
+        <widget class="caLineEdit" name="caLineEdit_9">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2404,7 +2281,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_22">
+        <widget class="caLabel" name="caLabel_21">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2491,7 +2368,7 @@ border-radius: 2px;
                 <enum>string</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_23">
+        <widget class="caLabel" name="caLabel_22">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2641,6 +2518,75 @@ border-radius: 2px;
                 <string>false;false;false;false</string>
             </property>
         </widget>
+        <widget class="caLabel" name="caLabel_23">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="text">
+                <string>Erase on Start?</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>5</x>
+                    <y>180</y>
+                    <width>110</width>
+                    <height>15</height>
+                </rect>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+        </widget>
+        <widget class="caChoice" name="caChoice_0">
+            <property name="geometry">
+                <rect>
+                    <x>120</x>
+                    <y>175</y>
+                    <width>120</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="channel">
+                <string>$(P):det1:EraseOnStart</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>200</red>
+                    <green>200</green>
+                    <blue>200</blue>
+                </color>
+            </property>
+            <property name="stackingMode">
+                <enum>Column</enum>
+            </property>
+            <property name="colorMode">
+                <enum>caChoice::Static</enum>
+            </property>
+        </widget>
         <zorder>caRectangle_0</zorder>
         <zorder>caLabel_0</zorder>
         <zorder>caLabel_1</zorder>
@@ -2676,7 +2622,6 @@ border-radius: 2px;
         <zorder>caLineEdit_2</zorder>
         <zorder>caByte_1</zorder>
         <zorder>caTextEntry_0</zorder>
-        <zorder>caChoice_0</zorder>
         <zorder>caTextEntry_1</zorder>
         <zorder>caTextEntry_2</zorder>
         <zorder>caTextEntry_3</zorder>
@@ -2688,20 +2633,20 @@ border-radius: 2px;
         <zorder>caRelatedDisplay_0</zorder>
         <zorder>caLineEdit_3</zorder>
         <zorder>caLineEdit_4</zorder>
-        <zorder>caLineEdit_5</zorder>
         <zorder>caMenu_0</zorder>
         <zorder>caTextEntry_4</zorder>
+        <zorder>caLineEdit_5</zorder>
         <zorder>caLineEdit_6</zorder>
         <zorder>caLineEdit_7</zorder>
         <zorder>caLineEdit_8</zorder>
-        <zorder>caLineEdit_9</zorder>
         <zorder>caMenu_1</zorder>
         <zorder>caTextEntry_5</zorder>
-        <zorder>caLineEdit_10</zorder>
+        <zorder>caLineEdit_9</zorder>
         <zorder>caTextEntry_6</zorder>
         <zorder>caMenu_2</zorder>
         <zorder>caRelatedDisplay_1</zorder>
         <zorder>caRelatedDisplay_2</zorder>
+        <zorder>caChoice_0</zorder>
     </widget>
 </widget>
 </ui>

--- a/xspress3App/opi/ui/xspress3_8chan.ui
+++ b/xspress3App/opi/ui/xspress3_8chan.ui
@@ -4,8 +4,8 @@
 <widget class="QMainWindow" name="MainWindow">
     <property name="geometry">
         <rect>
-            <x>690</x>
-            <y>186</y>
+            <x>400</x>
+            <y>250</y>
             <width>450</width>
             <height>525</height>
         </rect>
@@ -826,9 +826,9 @@ border-radius: 2px;
         <widget class="caTextEntry" name="caTextEntry_0">
             <property name="geometry">
                 <rect>
-                    <x>102</x>
+                    <x>120</x>
                     <y>120</y>
-                    <width>100</width>
+                    <width>80</width>
                     <height>20</height>
                 </rect>
             </property>
@@ -874,76 +874,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caChoice" name="caChoice_0">
-            <property name="geometry">
-                <rect>
-                    <x>155</x>
-                    <y>175</y>
-                    <width>120</width>
-                    <height>20</height>
-                </rect>
-            </property>
-            <property name="channel">
-                <string>$(P):det1:CTRL_DTC</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>200</red>
-                    <green>200</green>
-                    <blue>200</blue>
-                </color>
-            </property>
-            <property name="stackingMode">
-                <enum>Column</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caChoice::Static</enum>
-            </property>
-        </widget>
         <widget class="caLabel" name="caLabel_8">
-            <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="0">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="text">
-                <string>Dead Time Corr</string>
-            </property>
-            <property name="fontScaleMode">
-                <enum>ESimpleLabel::WidthAndHeight</enum>
-            </property>
-            <property name="geometry">
-                <rect>
-                    <x>5</x>
-                    <y>180</y>
-                    <width>150</width>
-                    <height>15</height>
-                </rect>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-        </widget>
-        <widget class="caLabel" name="caLabel_9">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1030,7 +961,7 @@ border-radius: 2px;
                 <enum>string</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_10">
+        <widget class="caLabel" name="caLabel_9">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1117,7 +1048,7 @@ border-radius: 2px;
                 <enum>string</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_11">
+        <widget class="caLabel" name="caLabel_10">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1507,61 +1438,7 @@ border-radius: 2px;
         <widget class="caLineEdit" name="caLineEdit_4">
             <property name="geometry">
                 <rect>
-                    <x>280</x>
-                    <y>175</y>
-                    <width>120</width>
-                    <height>15</height>
-                </rect>
-            </property>
-            <property name="fontScaleMode">
-                <enum>caLineEdit::WidthAndHeight</enum>
-            </property>
-            <property name="channel">
-                <string>$(P):det1:CTRL_DTC_RBV</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>10</red>
-                    <green>0</green>
-                    <blue>184</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>255</red>
-                    <green>255</green>
-                    <blue>255</blue>
-                </color>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="precisionMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="minValue">
-                <double>0.0</double>
-            </property>
-            <property name="maxValue">
-                <double>1.0</double>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-            <property name="formatType">
-                <enum>decimal</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caLineEdit::Static</enum>
-            </property>
-        </widget>
-        <widget class="caLineEdit" name="caLineEdit_5">
-            <property name="geometry">
-                <rect>
-                    <x>285</x>
+                    <x>270</x>
                     <y>210</y>
                     <width>120</width>
                     <height>15</height>
@@ -1615,7 +1492,7 @@ border-radius: 2px;
         <widget class="caMenu" name="caMenu_0">
             <property name="geometry">
                 <rect>
-                    <x>155</x>
+                    <x>120</x>
                     <y>210</y>
                     <width>120</width>
                     <height>20</height>
@@ -1642,7 +1519,7 @@ border-radius: 2px;
                 <enum>caMenu::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_12">
+        <widget class="caLabel" name="caLabel_11">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1681,9 +1558,9 @@ border-radius: 2px;
         <widget class="caTextEntry" name="caTextEntry_4">
             <property name="geometry">
                 <rect>
-                    <x>102</x>
+                    <x>120</x>
                     <y>145</y>
-                    <width>100</width>
+                    <width>80</width>
                     <height>20</height>
                 </rect>
             </property>
@@ -1729,7 +1606,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_6">
+        <widget class="caLineEdit" name="caLineEdit_5">
             <property name="geometry">
                 <rect>
                     <x>210</x>
@@ -1783,7 +1660,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_13">
+        <widget class="caLabel" name="caLabel_12">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1819,7 +1696,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_14">
+        <widget class="caLabel" name="caLabel_13">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1855,7 +1732,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_15">
+        <widget class="caLabel" name="caLabel_14">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1891,7 +1768,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_16">
+        <widget class="caLabel" name="caLabel_15">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1927,7 +1804,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_17">
+        <widget class="caLabel" name="caLabel_16">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1963,7 +1840,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_7">
+        <widget class="caLineEdit" name="caLineEdit_6">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2017,7 +1894,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_8">
+        <widget class="caLineEdit" name="caLineEdit_7">
             <property name="geometry">
                 <rect>
                     <x>170</x>
@@ -2071,7 +1948,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_18">
+        <widget class="caLabel" name="caLabel_17">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2107,7 +1984,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_9">
+        <widget class="caLineEdit" name="caLineEdit_8">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2161,7 +2038,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_19">
+        <widget class="caLabel" name="caLabel_18">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2227,7 +2104,7 @@ border-radius: 2px;
                 <enum>caMenu::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_20">
+        <widget class="caLabel" name="caLabel_19">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2314,7 +2191,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_21">
+        <widget class="caLabel" name="caLabel_20">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2350,7 +2227,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_10">
+        <widget class="caLineEdit" name="caLineEdit_9">
             <property name="geometry">
                 <rect>
                     <x>100</x>
@@ -2404,7 +2281,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_22">
+        <widget class="caLabel" name="caLabel_21">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2491,7 +2368,7 @@ border-radius: 2px;
                 <enum>string</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_23">
+        <widget class="caLabel" name="caLabel_22">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2641,6 +2518,75 @@ border-radius: 2px;
                 <string>false;false</string>
             </property>
         </widget>
+        <widget class="caLabel" name="caLabel_23">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="text">
+                <string>Erase on Start?</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>5</x>
+                    <y>180</y>
+                    <width>110</width>
+                    <height>15</height>
+                </rect>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+        </widget>
+        <widget class="caChoice" name="caChoice_0">
+            <property name="geometry">
+                <rect>
+                    <x>120</x>
+                    <y>175</y>
+                    <width>120</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="channel">
+                <string>$(P):det1:EraseOnStart</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>200</red>
+                    <green>200</green>
+                    <blue>200</blue>
+                </color>
+            </property>
+            <property name="stackingMode">
+                <enum>Column</enum>
+            </property>
+            <property name="colorMode">
+                <enum>caChoice::Static</enum>
+            </property>
+        </widget>
         <zorder>caRectangle_0</zorder>
         <zorder>caLabel_0</zorder>
         <zorder>caLabel_1</zorder>
@@ -2676,7 +2622,6 @@ border-radius: 2px;
         <zorder>caLineEdit_2</zorder>
         <zorder>caByte_1</zorder>
         <zorder>caTextEntry_0</zorder>
-        <zorder>caChoice_0</zorder>
         <zorder>caTextEntry_1</zorder>
         <zorder>caTextEntry_2</zorder>
         <zorder>caTextEntry_3</zorder>
@@ -2688,20 +2633,20 @@ border-radius: 2px;
         <zorder>caRelatedDisplay_0</zorder>
         <zorder>caLineEdit_3</zorder>
         <zorder>caLineEdit_4</zorder>
-        <zorder>caLineEdit_5</zorder>
         <zorder>caMenu_0</zorder>
         <zorder>caTextEntry_4</zorder>
+        <zorder>caLineEdit_5</zorder>
         <zorder>caLineEdit_6</zorder>
         <zorder>caLineEdit_7</zorder>
         <zorder>caLineEdit_8</zorder>
-        <zorder>caLineEdit_9</zorder>
         <zorder>caMenu_1</zorder>
         <zorder>caTextEntry_5</zorder>
-        <zorder>caLineEdit_10</zorder>
+        <zorder>caLineEdit_9</zorder>
         <zorder>caTextEntry_6</zorder>
         <zorder>caMenu_2</zorder>
         <zorder>caRelatedDisplay_1</zorder>
         <zorder>caRelatedDisplay_2</zorder>
+        <zorder>caChoice_0</zorder>
     </widget>
 </widget>
 </ui>

--- a/xspress3App/src/xspress3Epics.cpp
+++ b/xspress3App/src/xspress3Epics.cpp
@@ -206,6 +206,7 @@ void Xspress3::createInitialParameters()
     //createParam adds the parameters to all param lists automatically (using maxAddr).
     createParam(xsp3FirstParamString, asynParamInt32, &xsp3FirstParam);
     createParam(xsp3ResetParamString, asynParamInt32, &xsp3ResetParam);
+    createParam(xsp3EraseParamString, asynParamInt32, &xsp3EraseParam);
     createParam(xsp3EraseStartParamString, asynParamInt32, &xsp3EraseStartParam);
     createParam(xsp3NumChannelsParamString, asynParamInt32, &xsp3NumChannelsParam);
     createParam(xsp3MaxNumChannelsParamString, asynParamInt32, &xsp3MaxNumChannelsParam);

--- a/xspress3App/src/xspress3Epics.cpp
+++ b/xspress3App/src/xspress3Epics.cpp
@@ -1168,11 +1168,11 @@ asynStatus Xspress3::writeInt32(asynUser *pasynUser, epicsInt32 value)
 	    getIntegerParam(xsp3NumFramesDriverParam, &xsp3_time_frames);
 	    getIntegerParam(xsp3NumChannelsParam, &xsp3_num_channels);
 	    xsp3_status = xsp3->histogram_stop(xsp3_handle_, -1);
-	    // MNewville Sept 2021, use EraseOnStart to control whether
-	    // to Erase before Acquire
+	    // MNewville Sept 2021, use EraseOnStart to control whether to Erase before Acquire
 	    getIntegerParam(xsp3EraseStartParam, &xsp3_erasestart);
 	    if (xsp3_erasestart) {
 	      xsp3_status = xsp3->histogram_clear(xsp3_handle_, 0, xsp3_num_channels, 0, xsp3_time_frames);
+              asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, "%s Erased Before Data Collection\n", functionName);
 	    }
 
             setupITFG();

--- a/xspress3App/src/xspress3Epics.cpp
+++ b/xspress3App/src/xspress3Epics.cpp
@@ -1163,11 +1163,12 @@ asynStatus Xspress3::writeInt32(asynUser *pasynUser, epicsInt32 value)
       if (adStatus != ADStatusAcquire) {
 	  if ((status = checkConnected()) == asynSuccess) {
 	    asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, "%s Starting Data Collection.\n", functionName);
-	    //MNewville:  explicitly stop and clear histogram before starting.
+	    //MNewville:  explicitly stop histogram before starting.
 	    getIntegerParam(xsp3NumFramesDriverParam, &xsp3_time_frames);
 	    getIntegerParam(xsp3NumChannelsParam, &xsp3_num_channels);
 	    xsp3_status = xsp3->histogram_stop(xsp3_handle_, -1);
-	    xsp3_status = xsp3->histogram_clear(xsp3_handle_, 0, xsp3_num_channels, 0, xsp3_time_frames);
+	    // MNewville July 2021, do not clear histogram here
+	    // xsp3_status = xsp3->histogram_clear(xsp3_handle_, 0, xsp3_num_channels, 0, xsp3_time_frames);
             setupITFG();
 	    xsp3_status = xsp3->histogram_start(xsp3_handle_, -1 );
 	    if (xsp3_status != XSP3_OK) {

--- a/xspress3App/src/xspress3Epics.h
+++ b/xspress3App/src/xspress3Epics.h
@@ -62,6 +62,7 @@
 #define xsp3LastParamString              "XSP3_LAST"
 #define xsp3ResetParamString              "XSP3_RESET"
 #define xsp3EraseParamString              "XSP3_ERASE"
+#define xsp3EraseStartParamString              "XSP3_ERASESTART"
 #define xsp3NumChannelsParamString        "XSP3_NUM_CHANNELS"
 #define xsp3MaxNumChannelsParamString     "XSP3_MAX_NUM_CHANNELS"
 #define xsp3MaxSpectraParamString     "XSP3_MAX_SPECTRA"
@@ -215,6 +216,7 @@ class Xspress3 : public ADDriver {
   #define XSP3_FIRST_DRIVER_COMMAND xsp3FirstParam
   int xsp3ResetParam;
   int xsp3EraseParam;
+  int xsp3EraseStartParam;
   int xsp3NumChannelsParam;
   int xsp3MaxNumChannelsParam;
   int xsp3MaxSpectraParam;


### PR DESCRIPTION
This adds  `det1:EraseOnStart`  PV that controls whether ERASE is done on `det1:Acquire` (to satisfy existing usage) or whether `det1:Acquire` does not ERASE, matching ancient usage and also allowing `det1:ERASE` to be executed well before data acquisition, as part of an "arm" process. 

This is a work-in-progress, ready for comment and discussion. 

I think this is the simplest solution to #24 that can satisfy all use cases.  But, just to be clear, it is not quite ready for merging.  For example, not all the screens are updated. 