### PR TITLE
xraylarch updated repo

### DIFF
--- a/build_xspress3.py
+++ b/build_xspress3.py
@@ -44,7 +44,7 @@ other_sources = ('procServ-2.6.0.tar.gz', 'bin.tar.gz', 'medm_ext.tar.gz')
 SOURCES_URL = 'https://millenia.cars.aps.anl.gov/software/xspress3/sources'
 
 LARCH_URL   = 'https://millenia.cars.aps.anl.gov/xraylarch/downloads/'
-LARCH_FNAME = 'xraylarch-0.9.48-Linux-x86_64.sh'
+LARCH_FNAME = 'xraylarch-2022-04-Linux-x86_64.sh'
 
 ######################################################################
 required_tools = {'re2c': '/bin/re2c', 'rpcgen': '/bin/rpcgen',


### PR DESCRIPTION
The old repo name is no longer at that address, EPICS appears to work with the updated version of larch. Sorry for the pull request but just letting you know this was broken unless you put an archive in, or update this file to reflect package's new name.