### PR TITLE
adding ADCore PVs to be save/restored

### DIFF
--- a/iocs/xspress3IOC/iocBoot/ioc_8Channel/auto_settings.req
+++ b/iocs/xspress3IOC/iocBoot/ioc_8Channel/auto_settings.req
@@ -1,3 +1,5 @@
+file "ADBase_settings.req",  P=$(P), R=det1:
+
 file "built_settings.req",  P=$(P)
 file "NDFileHDF5_settings.req",  P=$(P), R=HDF1:
 file "NDROIStat_settings.req",   P=$(P), R=MCA1ROI:


### PR DESCRIPTION
I have been asked to add the base PVs to  the list of save/restored. It could be useful to others