### PR TITLE
Addin iocStats module to the common file loaded by all IOCs

### DIFF
--- a/iocs/xspress3IOC/iocBoot/common/DefineXSP3Driver.cmd
+++ b/iocs/xspress3IOC/iocBoot/common/DefineXSP3Driver.cmd
@@ -47,3 +47,6 @@ dbLoadRecords("NDFileHDF5.template",  "P=$(PREFIX),R=HDF1:,PORT=FileHDF1,ADDR=0,
 # load main template
 dbLoadRecords("xspress3.template","P=$(PREFIX),R=det1:,PORT=$(PORT), ADDR=0, TIMEOUT=5, MAX_SPECTRA=$(XSIZE), MAX_FRAMES=$(MAXFRAMES), HDF=$(PREFIX)HDF1:, PROC=$(PREFIX)Proc1:")
 
+# Optional: load devIocStats records (default config includes DEVIOCSTATS module), must define IOC_PREFIX in st.cmd
+dbLoadRecords("$(DEVIOCSTATS)/db/iocAdminSoft.db", "IOC=$(IOC_PREFIX)")
+


### PR DESCRIPTION
This line will load iocStats to all IOCs. IOC_PREFIX needs to be defined in st.cmd for a nChannel ioc 