### PR TITLE
Simplified Circularbuffer

### DIFF
--- a/xspress3App/src/xspress3Epics.cpp
+++ b/xspress3App/src/xspress3Epics.cpp
@@ -1954,7 +1954,7 @@ static void xsp3DataTaskC(void *xspAD)
     bool aborted=false;
     bool error=false;
 
-    int numChannels, maxSpectra, maxNumFrames, frameNumber, numFrames=0;
+    int numChannels, maxSpectra, maxNumFrames, frameNumber, numFrames=0, acquired, lastAcquired;
     //int frame_count, last_frame_count, frame_counter, frames_remaining, frame_offset;
     size_t dims[2];
     const double timeout = 0.00001;

--- a/xspress3App/src/xspress3Epics.cpp
+++ b/xspress3App/src/xspress3Epics.cpp
@@ -1684,6 +1684,7 @@ bool Xspress3::readFrame(u_int32_t* pSCA, u_int32_t* pMCAData, int frameNumber, 
         {
         setIntegerParam(NDArrayCounter, frameNumber+1);
     }
+    }
 //    xsp3_histogram_circ_ack(this->xsp3_handle_, 0, frameOffset, this->numChannels_, 1);
     if (circBuffer_ == 1) {
     	xsp3_histogram_circ_ack(this->xsp3_handle_, 0, frameNumber, this->numChannels_, 1);

--- a/xspress3App/src/xspress3Epics.cpp
+++ b/xspress3App/src/xspress3Epics.cpp
@@ -1261,9 +1261,10 @@ asynStatus Xspress3::writeInt32(asynUser *pasynUser, epicsInt32 value)
       }
   }
   else if (function == ADNumImages) {
-    printf("Changed the number of images");
     asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, "%s Set Number Of Frames To Read Out.\n", functionName);
     getIntegerParam(xsp3NumFramesDriverParam, &xsp3_time_frames);
+    printf("We are trying to set a value of %i\n" % value);
+    printf("The maximum value is %i\n" xsp3_time_frames);
     if (value > xsp3_time_frames) {
       asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "%s ERROR: Num Frames Higher Than Number Configured.\n", functionName);
       status = asynError;

--- a/xspress3App/src/xspress3Epics.cpp
+++ b/xspress3App/src/xspress3Epics.cpp
@@ -1261,6 +1261,7 @@ asynStatus Xspress3::writeInt32(asynUser *pasynUser, epicsInt32 value)
       }
   }
   else if (function == ADNumImages) {
+    printf("Changed the number of images");
     asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, "%s Set Number Of Frames To Read Out.\n", functionName);
     getIntegerParam(xsp3NumFramesDriverParam, &xsp3_time_frames);
     if (value > xsp3_time_frames) {

--- a/xspress3App/src/xspress3Epics.cpp
+++ b/xspress3App/src/xspress3Epics.cpp
@@ -1263,8 +1263,8 @@ asynStatus Xspress3::writeInt32(asynUser *pasynUser, epicsInt32 value)
   else if (function == ADNumImages) {
     asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, "%s Set Number Of Frames To Read Out.\n", functionName);
     getIntegerParam(xsp3NumFramesDriverParam, &xsp3_time_frames);
-    printf("We are trying to set a value of %i\n" % value);
-    printf("The maximum value is %i\n" xsp3_time_frames);
+    printf("We are trying to set a value of %i\n", value);
+    printf("The maximum value is %i\n", xsp3_time_frames);
     if (value > xsp3_time_frames) {
       asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "%s ERROR: Num Frames Higher Than Number Configured.\n", functionName);
       status = asynError;

--- a/xspress3App/src/xspress3Epics.cpp
+++ b/xspress3App/src/xspress3Epics.cpp
@@ -1265,9 +1265,6 @@ asynStatus Xspress3::writeInt32(asynUser *pasynUser, epicsInt32 value)
     asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, "%s Set Number Of Frames To Read Out.\n", functionName);
     getIntegerParam(xsp3NumFramesDriverParam, &xsp3_time_frames);
     getIntegerParam(xsp3MaxFramesParam, &xsp3_time_frames2);
-    printf("We are trying to set a value of %i\n", value);
-    printf("The maximum value is %i\n", xsp3_time_frames);
-    printf("The other maximum value is %i\n", xsp3_time_frames2);
     if (value > xsp3_time_frames || value > xsp3_time_frames2) {
       asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "%s ERROR: Num Frames Higher Than Number Configured.\n", functionName);
       status = asynError;

--- a/xspress3App/src/xspress3Epics.cpp
+++ b/xspress3App/src/xspress3Epics.cpp
@@ -1658,8 +1658,8 @@ bool Xspress3::readFrame(double* pSCA, double* pMCAData, int frameNumber, int ma
     } else {
         setIntegerParam(NDArrayCounter, frameNumber+1);
     }
-
-    	xsp3_histogram_circ_ack(this->xsp3_handle_, 0, frameNumber, this->numChannels_, 1);
+    if (circBuffer_ == 1) {
+          xsp3_histogram_circ_ack(this->xsp3_handle_, 0, frameNumber, this->numChannels_, 1);
     }
     return error;
 }

--- a/xspress3App/src/xspress3Epics.cpp
+++ b/xspress3App/src/xspress3Epics.cpp
@@ -1263,8 +1263,10 @@ asynStatus Xspress3::writeInt32(asynUser *pasynUser, epicsInt32 value)
   else if (function == ADNumImages) {
     asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, "%s Set Number Of Frames To Read Out.\n", functionName);
     getIntegerParam(xsp3NumFramesDriverParam, &xsp3_time_frames);
+    getIntegerParam(xsp3MaxFramesParam, &xsp3_time_frames2);
     printf("We are trying to set a value of %i\n", value);
     printf("The maximum value is %i\n", xsp3_time_frames);
+    printf("The other maximum value is %i\n", xsp3_time_frames2);
     if (value > xsp3_time_frames) {
       asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "%s ERROR: Num Frames Higher Than Number Configured.\n", functionName);
       status = asynError;

--- a/xspress3App/src/xspress3Epics.cpp
+++ b/xspress3App/src/xspress3Epics.cpp
@@ -1268,7 +1268,7 @@ asynStatus Xspress3::writeInt32(asynUser *pasynUser, epicsInt32 value)
     printf("We are trying to set a value of %i\n", value);
     printf("The maximum value is %i\n", xsp3_time_frames);
     printf("The other maximum value is %i\n", xsp3_time_frames2);
-    if (value > xsp3_time_frames) {
+    if (value > xsp3_time_frames || value > xsp3_time_frames2) {
       asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "%s ERROR: Num Frames Higher Than Number Configured.\n", functionName);
       status = asynError;
     }

--- a/xspress3App/src/xspress3Epics.cpp
+++ b/xspress3App/src/xspress3Epics.cpp
@@ -1149,6 +1149,7 @@ asynStatus Xspress3::writeInt32(asynUser *pasynUser, epicsInt32 value)
   int xsp3_status = 0;
   int xsp3_sca_lim = 0;
   int xsp3_time_frames = 0;
+  int xsp3_time_frames2 =0;
   int adStatus = 0;
   asynStatus status = asynSuccess;
   int xsp3_num_channels = 0;

--- a/xspress3App/src/xspress3Epics.h
+++ b/xspress3App/src/xspress3Epics.h
@@ -139,8 +139,8 @@ class Xspress3 : public ADDriver {
   void adReportError(const char* message);
   bool createMCAArray(size_t dims[2], NDArray *&pMCA, NDDataType_t dataType);
   bool createSCAArray(void *&pSCA);
-  bool readFrame(double* pSCA, double* pMCAData, int frameNumber, int maxSpectra, int framesRemaining);
-  bool readFrame(u_int32_t* pSCA, u_int32_t* pMCAData, int frameNumber, int maxSpectra, int framesRemaining);
+  bool readFrame(double* pSCA, double* pMCAData, int frameNumber, int maxSpectra);
+  bool readFrame(u_int32_t* pSCA, u_int32_t* pMCAData, int frameNumber, int maxSpectra);
   void writeOutScas(void *&pSCA, int numChannels, NDDataType_t dataType);
   void setStartingParameters();
   const NDDataType_t getDataType();


### PR DESCRIPTION
Minimal Circular buffer that should run the same as the non-circular buffer. No longer uses the FrameRemaining technique. From my testing, this runs at the same max speed as the non-circular buffer. 