### PR TITLE
Allow alternative architecture names

### DIFF
--- a/xspress3App/src/Makefile
+++ b/xspress3App/src/Makefile
@@ -8,8 +8,10 @@ include $(TOP)/configure/CONFIG
 
 DATA+=xsp3.xml
 
-ifeq (linux-x86_64, $(findstring linux-x86_64, $(T_A)))
+ifeq (Linux, $(OS_CLASS))
+ifeq (x86_64, $(ARCH_CLASS))
   LIBRARY_IOC_Linux += xspress3Epics
+endif
 endif
 
 DBD += xspress3Support.dbd

--- a/xspress3Support/Makefile
+++ b/xspress3Support/Makefile
@@ -12,7 +12,8 @@ INC += xspress3_dma_protocol.h
 INC += os9types.h
 INC += xspress3_data_mod.h
 
-ifeq (linux-x86_64, $(findstring linux-x86_64, $(T_A)))
+ifeq (Linux, $(OS_CLASS))
+ifeq (x86_64, $(ARCH_CLASS))
 #LIB_INSTALLS_Linux += ../os/$(T_A)/libFemClient.a
 LIB_INSTALLS_Linux += ../os/linux-x86_64/libxspress3.so.1.0
 LIB_INSTALLS_Linux += ../os/linux-x86_64/libimg_mod.so.1.0
@@ -24,6 +25,7 @@ LIB_INSTALLS_Linux += ../os/linux-x86_64/libimg_mod.so
 #BIN_INSTALLS_Linux += ../os/linux-x86_64/imgd
 #BIN_INSTALLS_Linux += ../os/linux-x86_64)/xspress3test
 #BIN_INSTALLS_Linux += ../os/linux-x86_64)/xspress3.server
+endif
 endif
 
 #=============================


### PR DESCRIPTION
While epics-base recommends that custom Linux EPICS target architectures use a naming convention like linux-x86_64-something, that isn't necessarily a requirement as I've unfortunately come across. It would be useful if the Makefiles explicitly checked for a linux OS and an x86_64 architecture rather than trying to parse that out of the target name.