### PR TITLE
Install static versions of xspress3 and img_mod libraries to build wi…

### DIFF
--- a/xspress3Support/Makefile
+++ b/xspress3Support/Makefile
@@ -19,6 +19,8 @@ LIB_INSTALLS_Linux += ../os/linux-x86_64/libxspress3.so.1.0
 LIB_INSTALLS_Linux += ../os/linux-x86_64/libimg_mod.so.1.0
 LIB_INSTALLS_Linux += ../os/linux-x86_64/libxspress3.so
 LIB_INSTALLS_Linux += ../os/linux-x86_64/libimg_mod.so
+LIB_INSTALLS_Linux += ../os/linux-x86_64/libxspress3.a
+LIB_INSTALLS_Linux += ../os/linux-x86_64/libimg_mod.a
 
 #LIB_INSTALLS_Linux += ../os/linux-x86_64)/libXspress3FemApi.a
 


### PR DESCRIPTION
…th STATIC_BUILD=YES

At the moment, it seems if you perform a build with `STATIC_BUILD=YES` you get an error about how `-lxspress3` and `-limg_mod` could not be found.