### PR TITLE
Allow for overriding CONFIG_SITE with a *.local

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -40,3 +40,5 @@ ifdef T_A
   -include $(AREA_DETECTOR)/configure/CONFIG_SITE.Common.$(T_A)
   -include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
 endif
+
+-include $(TOP)/configure/CONFIG_SITE.local

--- a/iocs/xspress3IOC/configure/CONFIG_SITE
+++ b/iocs/xspress3IOC/configure/CONFIG_SITE
@@ -40,3 +40,5 @@ ifdef T_A
   -include $(AREA_DETECTOR)/configure/CONFIG_SITE.Common.$(T_A)
   -include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
 endif
+
+-include $(TOP)/configure/CONFIG_SITE.local


### PR DESCRIPTION
Allow for overriding CONFIG_SITE with a `.local` version to facilitate building outside of the traditional `areaDetector/configure` structure.