### PR TITLE
Remove FrameAdvance dbpf from SetMainValues as PV does not exist

### DIFF
--- a/iocs/xspress3IOC/iocBoot/common/SetMainValues.cmd
+++ b/iocs/xspress3IOC/iocBoot/common/SetMainValues.cmd
@@ -7,7 +7,6 @@ dbpf("$(PREFIX)det1:CONNECT",      "1")
 dbpf("$(PREFIX)det1:CTRL_DTC",     "Disable")
 dbpf("$(PREFIX)det1:TriggerMode",  "Internal")
 dbpf("$(PREFIX)det1:EraseOnStart", "Yes")
-dbpf("$(PREFIX)det1:FrameAdvance", 0)
 
 #Enable Array Callbacks, set Attributes file
 dbpf("$(PREFIX)det1:ArrayCallbacks",   "Enable")


### PR DESCRIPTION
This removes the dbpf introduced in #41 and resolves #58.