### PR TITLE
Feature/release notes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,7 +51,7 @@ Fixed:
 
 Added:
 
-- Update to support Xspress 3 Mini Mk2 systems
+- Updated to version r568 (2024-12-19) to support Xspress 3 Mini Mk2 systems
 
 Changed:
 


### PR DESCRIPTION
This adds a release notes file so we can start tracking the changes between releases.

Due to the number of changes and support for Xspress 3 Mini Mk2 I suggest we call the next release v4.0.0.

I have also written this assuming #68 and #71 get merged in as well.