### PR TITLE
Explicitly set data source in channel control registers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,7 +45,10 @@ Fixed:
   in `xspress3Epics.cpp` which caused some synchronisation problems.
 - Removed duplicate calls to `setupITFG()` and `histogram_start` when starting
   an acquisition
-
+- Now explicitly set channel control registers to the desired data source (based
+  on `$(PREFIX)det1:RUN_FLAGS`) between real and playback data. This fixes an
+  issue where real data could not be acquired if the settings files being
+  loaded include playback data.
 
 ### Library
 

--- a/xspress3App/src/xsp3Api.cpp
+++ b/xspress3App/src/xsp3Api.cpp
@@ -458,3 +458,39 @@ int xsp3Api::get_generation(int path, int card)
     return status;
 
 }
+
+int xsp3Api::get_chan_cont(int path, int chan, u_int32_t *chan_cont)
+{
+    int status;
+    asynPrint(this->pasynUser, XSP3IF_DEBUG, "xsp3_get_chan_cont( %i, %i, %i ) = ", path, chan, *(chan_cont) );
+
+    status = xsp3Api_get_chan_cont(path, chan, chan_cont);
+
+    asynPrint(this->pasynUser, XSP3IF_DEBUG, "%d\n", status );
+
+    return status;
+}
+
+int xsp3Api::set_chan_cont(int path, int chan, u_int32_t chan_cont)
+{
+    int status;
+    asynPrint(this->pasynUser, XSP3IF_DEBUG, "xsp3_set_chan_cont( %i, %i, %i ) = ", path, chan, chan_cont );
+
+    status = xsp3Api_set_chan_cont(path, chan, chan_cont);
+
+    asynPrint(this->pasynUser, XSP3IF_DEBUG, "%d\n", status );
+
+    return status;
+}
+
+int xsp3Api::set_chan_cont2(int path, int chan, u_int32_t chan_cont2)
+{
+    int status;
+    asynPrint(this->pasynUser, XSP3IF_DEBUG, "xsp3_set_chan_cont2( %i, %i, %i ) = ", path, chan, chan_cont2 );
+
+    status = xsp3Api_set_chan_cont2(path, chan, chan_cont2);
+
+    asynPrint(this->pasynUser, XSP3IF_DEBUG, "%d\n", status );
+
+    return status;
+}

--- a/xspress3App/src/xsp3Api.h
+++ b/xspress3App/src/xsp3Api.h
@@ -73,6 +73,9 @@ protected:
     virtual int xsp3Api_get_dtcfactor(int path, u_int32_t *scaData, double *dtcFactor, double *dtcAllEvent, unsigned chan) = 0;
     virtual int xsp3Api_get_generation(int path, int card) = 0;
     virtual int xsp3Api_set_sync_mode(int path, int sync_mode, int enb_global_reset, int gr_card) = 0;
+    virtual int xsp3Api_get_chan_cont(int path, int chan, u_int32_t *chan_cont) = 0;
+    virtual int xsp3Api_set_chan_cont(int path, int chan, u_int32_t chan_cont) = 0;
+    virtual int xsp3Api_set_chan_cont2(int path, int chan, u_int32_t chan_cont2) = 0;
 
 public:
     int clocks_setup(int path, int card, int clk_src, int flags, int tp_type);
@@ -112,6 +115,9 @@ public:
     int get_dtcfactor(int path, u_int32_t *scaData, double *dtcFactor, double *dtcAllEvent, unsigned chan);
     int get_generation(int path, int card);
     int set_sync_mode(int path, int sync_mode, int enb_global_reset, int gr_card);
+    int get_chan_cont(int path, int chan, u_int32_t *chan_cont);
+    int set_chan_cont(int path, int chan, u_int32_t chan_cont);
+    int set_chan_cont2(int path, int chan, u_int32_t chan_cont2);
 
 private:
     asynUser * pasynUser;

--- a/xspress3App/src/xsp3Detector.cpp
+++ b/xspress3App/src/xsp3Detector.cpp
@@ -261,3 +261,27 @@ int xsp3Detector::xsp3Api_set_sync_mode(int path, int sync_mode, int enb_global_
 
     return status;
 }
+
+int xsp3Detector::xsp3Api_get_chan_cont(int path, int chan, u_int32_t *chan_cont)
+{
+    int status;
+    status = xsp3_get_chan_cont(path, chan, chan_cont);
+
+    return status;
+}
+
+int xsp3Detector::xsp3Api_set_chan_cont(int path, int chan, u_int32_t chan_cont)
+{
+    int status;
+    status = xsp3_set_chan_cont(path, chan, chan_cont);
+
+    return status;
+}
+
+int xsp3Detector::xsp3Api_set_chan_cont2(int path, int chan, u_int32_t chan_cont2)
+{
+    int status;
+    status = xsp3_set_chan_cont2(path, chan, chan_cont2);
+
+    return status;
+}

--- a/xspress3App/src/xsp3Detector.h
+++ b/xspress3App/src/xsp3Detector.h
@@ -72,6 +72,9 @@ protected:
     virtual int xsp3Api_get_dtcfactor(int path, u_int32_t *scaData, double *dtcFactor, double *dtcAllEvent, unsigned chan);
     virtual int xsp3Api_get_generation(int path, int card);
     virtual int xsp3Api_set_sync_mode(int path, int sync_mode, int enb_global_reset, int gr_card);
+    virtual int xsp3Api_get_chan_cont(int path, int chan, u_int32_t *chan_cont);
+    virtual int xsp3Api_set_chan_cont(int path, int chan, u_int32_t chan_cont);
+    virtual int xsp3Api_set_chan_cont2(int path, int chan, u_int32_t chan_cont2);
 };
 
 #endif /* XSP3DETECTOR_H */

--- a/xspress3App/src/xsp3Simulator.cpp
+++ b/xspress3App/src/xsp3Simulator.cpp
@@ -254,3 +254,15 @@ int xsp3Simulator::xsp3Api_set_sync_mode(int path, int sync_mode, int enb_global
 {
     return XSP3_OK;
 }
+int xsp3Simulator::xsp3Api_get_chan_cont(int path, int chan, u_int32_t *chan_cont)
+{
+    return XSP3_OK;
+}
+int xsp3Simulator::xsp3Api_set_chan_cont(int path, int chan, u_int32_t chan_cont)
+{
+    return XSP3_OK;
+}
+int xsp3Simulator::xsp3Api_set_chan_cont2(int path, int chan, u_int32_t chan_cont2)
+{
+    return XSP3_OK;
+}

--- a/xspress3App/src/xsp3Simulator.h
+++ b/xspress3App/src/xsp3Simulator.h
@@ -79,6 +79,9 @@ protected:
     virtual int xsp3Api_get_dtcfactor(int path, u_int32_t *scaData, double *dtcFactor, double *dtcAllEvent, unsigned chan);
     virtual int xsp3Api_get_generation(int path, int card);
     virtual int xsp3Api_set_sync_mode(int path, int sync_mode, int enb_global_reset, int gr_card);
+    virtual int xsp3Api_get_chan_cont(int path, int chan, u_int32_t *chan_cont);
+    virtual int xsp3Api_set_chan_cont(int path, int chan, u_int32_t chan_cont);
+    virtual int xsp3Api_set_chan_cont2(int path, int chan, u_int32_t chan_cont2);
 
 private:
     std::vector<xsp3SimElement> detectors;


### PR DESCRIPTION
This updates the logic in `Xspress3::restoreSettings` to explicitly set the channel control registers to a specific data source after the settings files have been loaded.

**Background**

The PV `$(PREFIX)det1:RUN_FLAGS` in `SetMainValues.cmd` is used to change the run flags (i.e. the readout mode of the Xspress system) between normal and playback data. The intention was to allow the user to choose between using test playback data or collecting real data by just changing the value of this PV and rebooting the IOC.

However, this is not the full picture. If the user sets the config path (`$(PREFIX)det1:CONFIG_PATH`) to settings files which include playback data, then the channel control registers have their data source set to playback data when these are loaded (this happens inside the Xspress 3 library).

So in this case the user wouldn't be able to collect real ADC data, even if they set the RUN_FLAGS PV to 0.

A workaround for the user is to set an environment variable `XSP3PLAYBACK=adc` to override the data source that is set by the Xspress 3 library, but I think it makes more sense/nicer for it to be handled automatically in the IOC.

**Changes**

This change now adds setting the data source of each channel explicitly after the settings files have been loaded, based on the value of `$(PREFIX)det1:RUN_FLAGS`:

1. If the value is set to 0, then the data source is set to XSP3_CC_SEL_DATA_NORMAL (i.e. real data)
2. If the value is set to 1, then the data source is set to XSP3_CC_SEL_DATA_PB_CHAN (i.e. playback data)
