### PR TITLE
Fix race condition in parallel source extraction

### DIFF
--- a/build_xspress3.py
+++ b/build_xspress3.py
@@ -349,7 +349,7 @@ def extract_sources():
             for tarball in other_sources:
                 w = pool.apply_async(unpack_tarball, (tarball, None, 'sources'))
                 workers.append(w)
-            [w.wait() for w in workers]
+            [w.get() for w in workers]
 
     os.chdir('areaDetector')
     for key, value  in ad_modules.items():

--- a/build_xspress3.py
+++ b/build_xspress3.py
@@ -294,8 +294,10 @@ def create_bindir():
         print("# fetch %s" % ('%s/%s' % (SOURCES_URL, tarball)))
         o = sp.call(['/bin/wget', '%s/%s' % (SOURCES_URL, tarball)])
         os.chdir(cwd)
-    if not os.path.exists('bin'):
+    try:
         os.mkdir('bin')
+    except OSError:
+        pass
     if not os.path.exists(tball):
         print("# download failed! for %s" % tball)
     else:
@@ -305,8 +307,10 @@ def create_bindir():
 def unpack_tarball(tarball, shortname, sourcedir):
     tball = os.path.join(sourcedir, tarball)
     cwd = os.path.abspath(os.getcwd())
-    if not os.path.exists(sourcedir):
+    try:
         os.mkdir(sourcedir)
+    except OSError:
+        pass
     if not os.path.exists(tball):
         os.chdir(sourcedir)
         print("# fetch %s" % ('%s/%s' % (SOURCES_URL, tarball)))


### PR DESCRIPTION
Fix a race in parallel source extraction where multiple workers could attempt to create the same source directory and fail silently. Replacing .wait() with .get() exposed the worker exception, and making directory creation race-safe prevents incomplete downloads.