### PR TITLE
changed record type in xspress3ChannelDeadtime.template

### DIFF
--- a/xspress3App/Db/xspress3ChannelDeadtime.template
+++ b/xspress3App/Db/xspress3ChannelDeadtime.template
@@ -27,14 +27,14 @@ record(ai, "$(P)C$(CHAN):DTFactor_RBV") {
 # energy calibration convenience values for downstream apps, in case calibration drifts from 10 eV/bin
 # calibration offset
 record(ao, "$(P)C$(CHAN):CALO") {
-    field(DTYP, "float")
+    field(DTYP, "Soft Channel")
     field(DESC, "Energy Calibration offset")
     field(VAL,  "0.0000")
     field(PREC, "5")
 }
 # calibration slope
 record(ao, "$(P)C$(CHAN):CALS") {
-    field(DTYP, "float")
+    field(DTYP, "Soft Channel")
     field(DESC, "Energy Calibration slope (keV/bin)")
     field(VAL,  "0.0100")
     field(PREC, "5")
@@ -42,7 +42,7 @@ record(ao, "$(P)C$(CHAN):CALS") {
 
 # calibration quadratic
 record(ao, "$(P)C$(CHAN):CALQ") {
-    field(DTYP, "float")
+    field(DTYP, "Soft Channel")
     field(DESC, "Energy Calibration quadratic (keV^2/bin)")
     field(VAL,  "0.0000")
     field(PREC, "5")


### PR DESCRIPTION
Hello, I have been trying to install this IOC and have encountered errors regarding record types in `xspress3ChannelDeadtime.template` 

```
ERROR: Can't set '<IOC_NAME>:C5:CALS.DTYP' to 'float' no such device support for 'ao' record type : Illegal choice
    Did you mean "asynFloat64"?
ERROR:
 37 |     field(DTYP, "float")
```

I have tested that this problem is fixed if I change the values from `float` to `Soft Channel` . I would be happy if you have a look at this PR. Thanks!